### PR TITLE
shutdown client resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ A UDP socket can be generated using `(aleph.udp/socket {:port 10001, :broadcast?
 
 Where incoming packets will have a `:message` that is a Netty `ByteBuf` that can be coerced using `byte-streams`, and outgoing packets can be any data which can be coerced to a binary representation.  If no `:port` is specified, the socket can only be used to send messages.
 
+### Client Shutdown
+
+All aleph clients use a shared Netty `EventLoopGroup`. If any aleph client is used, this resource must be shutdown via `(aleph.netty/shutdown-client-resources)` before the host application will be able to exit.
+
 ### license
 
 Copyright © 2014 Zachary Tellman

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -375,9 +375,7 @@
 
 (defn create-client
   [pipeline-builder ssl-context bootstrap-transform host port]
-  (let [^EventLoopGroup
-
-        ^Class
+  (let [^Class
         channel (if (epoll?)
                   EpollSocketChannel
                   NioSocketChannel)

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -406,7 +406,7 @@
               ch)))))))
 
 (defn shutdown-client-resources []
-  (-> client-group .shutdownGracefully wrap-future))
+  (-> ^EventLoopGroup client-group .shutdownGracefully wrap-future))
 
 (defn start-server
   [pipeline-builder

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -407,6 +407,9 @@
             (let [ch (.channel ^ChannelFuture f)]
               ch)))))))
 
+(defn shutdown-client-resources []
+  (-> client-group .shutdownGracefully wrap-future))
+
 (defn start-server
   [pipeline-builder
    ssl-context


### PR DESCRIPTION
Hi Zach,

I noticed that my application wasn't able to exit after using an aleph client. I found that I needed to call shutdownGracefully on the shared EventLoopGroup used by the clients. It looks like you had this call originally but it was removed when you changed to the shared event group.

This PR adds a convenience function for this shutdown, along with some documentation, if you're interested.

I have another branch that, instead, configures this shared event group to use daemon threads so they will be killed automatically on application exit. But, I'm assuming you would not want to preclude aleph from being used in applications where the clients are intended to continue after the main application exits. If I'm wrong about that, let me know and I'll submit that PR.

Thanks.
  -Tony