### PR TITLE
shared client event group uses daemon threads

### DIFF
--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -172,10 +172,10 @@
 
 (deftest test-default-event-loop-threads
   (let [initial-threads-property (System/getProperty netty-threads-property-name)]
-    (testing "Default event thread count is even."
+    (testing "Default event thread count is twice the cpu count."
       (System/clearProperty netty-threads-property-name)
       (let [default-threads (netty/get-default-event-loop-threads)]
-        (is (even? default-threads))
+        (is (= default-threads (->> (Runtime/getRuntime) (.availableProcessors) (* 2))))
         (testing "Netty eventLoopThreads property overrides default thread count"
           (let [property-threads (inc default-threads)]
             (System/setProperty netty-threads-property-name (str property-threads))


### PR DESCRIPTION
The EventLoopGroup shared by the clients is configured to use daemon threads so they will be killed automatically when the host application exits.

Unfortunately, I had to mimic the code in Netty's [MultithreadEventLoopGroup](https://github.com/netty/netty/blob/master/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java) to determine the default number of threads to use. I don't see a way to get that default from Netty directly.

Let me know if there are any adjustments you'd like me to make.

   -Tony