### PR TITLE
HTTP connection and request timeouts

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -206,9 +206,12 @@
                     (-> (middleware conn')
                       (d/chain #(% req))
                       (maybe-timeout! request-timeout)
-                      (d/catch TimeoutException
-                               #(do (flow/dispose pool k conn) (throw %)))
-                      (d/catch #(do (flow/release pool k conn) (throw %)))
+                      (d/catch
+                        (fn [e]
+                          (if (instance? TimeoutException e)
+                            (flow/dispose pool k conn)
+                            (flow/release pool k conn))
+                          (throw e)))
                       (d/chain
                         (fn [rsp]
                           (d/chain (:aleph/complete rsp)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -12,7 +12,9 @@
     [io.aleph.dirigiste Pools]
     [java.net
      URI
-     InetSocketAddress]))
+     InetSocketAddress]
+    [java.util.concurrent
+     TimeoutException]))
 
 (defn start-server
   "Starts an HTTP server using the provided Ring `handler`.  Returns a server object which can be stopped
@@ -164,33 +166,55 @@
 
 (defn request
   "Takes an HTTP request, as defined by the Ring protocol, with the extensions defined
-   by [clj-http](https://github.com/dakrone/clj-http), and returns a deferred representing the HTTP response.  Also allows for a custom `pool` or `middleware` to be defined."
-  [{:keys [pool middleware socket-timeout]
+   by [clj-http](https://github.com/dakrone/clj-http), and returns a deferred representing
+   the HTTP response.  Also allows for a custom `pool` or `middleware` to be defined.
+
+   |:---|:---
+   | `pool` | a custom connection pool
+   | `middleware` | custom client middleware for the request
+   | `socket-timeout` | timeout in milliseconds for the pool to allocate a socket
+   | `connection-timeout` | timeout in milliseconds for the connection to become established
+   | `request-timeout` | timeout in milliseconds for the arrival of a response over the established connection"
+  [{:keys [pool
+           middleware
+           socket-timeout
+           connection-timeout
+           request-timeout]
     :or {pool default-connection-pool
          middleware identity}
     :as req}]
   (let [k (client/req->domain req)
         start (System/currentTimeMillis)
-        conn (flow/acquire pool k)]
-    (d/chain (if socket-timeout
-               (d/timeout! conn socket-timeout)
-               conn)
-      (fn [conn]
-        (-> (first conn)
-          (d/chain
-            (fn [conn']
-              (let [end (System/currentTimeMillis)]
-                (-> (middleware conn')
-                  (d/chain #(% req))
-                  (d/catch #(do (flow/release pool k conn) (throw %)))
-                  (d/chain
-                    (fn [rsp]
-                      (d/chain (:aleph/complete rsp)
-                        (fn [_]
-                          (flow/release pool k conn)))
-                      (-> rsp
-                        (dissoc :aleph/complete)
-                        (assoc :connection-time (- end start))))))))))))))
+        maybe-timeout! (fn [d timeout]
+                         (if timeout
+                           (d/timeout! d timeout)
+                           d))]
+    (-> (flow/acquire pool k)
+      (maybe-timeout! socket-timeout)
+      (d/chain
+        (fn [conn]
+          (-> (first conn)
+            (maybe-timeout! connection-timeout)
+            (d/catch TimeoutException
+                     #(do (flow/dispose pool k conn) (throw %)))
+            (d/chain
+              (fn [conn']
+                (let [connection-end (System/currentTimeMillis)
+                      connection-time (- connection-end start)]
+                  (-> (middleware conn')
+                    (d/chain #(% req))
+                    (maybe-timeout! request-timeout)
+                    (d/catch TimeoutException
+                             #(do (flow/dispose pool k conn) (throw %)))
+                    (d/catch #(do (flow/release pool k conn) (throw %)))
+                    (d/chain
+                      (fn [rsp]
+                        (d/chain (:aleph/complete rsp)
+                          (fn [_]
+                            (flow/release pool k conn)))
+                        (-> rsp
+                          (dissoc :aleph/complete)
+                          (assoc :connection-time connection-time))))))))))))))
 
 (defn- req
   ([method url]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -206,12 +206,7 @@
                     (-> (middleware conn')
                       (d/chain #(% req))
                       (maybe-timeout! request-timeout)
-                      (d/catch
-                        (fn [e]
-                          (if (instance? TimeoutException e)
-                            (flow/dispose pool k conn)
-                            (flow/release pool k conn))
-                          (throw e)))
+                      (d/catch #(do (flow/dispose pool k conn) (throw %)))
                       (d/chain
                         (fn [rsp]
                           (d/chain (:aleph/complete rsp)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -165,16 +165,15 @@
 (defn request
   "Takes an HTTP request, as defined by the Ring protocol, with the extensions defined
    by [clj-http](https://github.com/dakrone/clj-http), and returns a deferred representing the HTTP response.  Also allows for a custom `pool` or `middleware` to be defined."
-  [{:keys [pool middleware]
+  [{:keys [pool middleware socket-timeout]
     :or {pool default-connection-pool
          middleware identity}
     :as req}]
   (let [k (client/req->domain req)
         start (System/currentTimeMillis)
-        timeout (clojure.core/get req :socket-timeout)
         conn (flow/acquire pool k)]
-    (d/chain (if timeout
-               (d/timeout! conn timeout)
+    (d/chain (if socket-timeout
+               (d/timeout! conn socket-timeout)
                conn)
       (fn [conn]
         (-> (first conn)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -177,22 +177,21 @@
                (d/timeout! conn timeout)
                conn)
       (fn [conn]
-        (let [end (System/currentTimeMillis)]
-          (-> (first conn)
-            (d/chain
-              (fn [conn']
-                (let [end (System/currentTimeMillis)]
-                  (-> (middleware conn')
-                    (d/chain #(% req))
-                    (d/catch #(do (flow/release pool k conn) (throw %)))
-                    (d/chain
-                      (fn [rsp]
-                        (d/chain (:aleph/complete rsp)
-                          (fn [_]
-                            (flow/release pool k conn)))
-                        (-> rsp
-                          (dissoc :aleph/complete)
-                          (assoc :connection-time (- end start)))))))))))))))
+        (-> (first conn)
+          (d/chain
+            (fn [conn']
+              (let [end (System/currentTimeMillis)]
+                (-> (middleware conn')
+                  (d/chain #(% req))
+                  (d/catch #(do (flow/release pool k conn) (throw %)))
+                  (d/chain
+                    (fn [rsp]
+                      (d/chain (:aleph/complete rsp)
+                        (fn [_]
+                          (flow/release pool k conn)))
+                      (-> rsp
+                        (dissoc :aleph/complete)
+                        (assoc :connection-time (- end start))))))))))))))
 
 (defn- req
   ([method url]

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -13,7 +13,9 @@
      Executors]
     [java.io
      File
-     ByteArrayInputStream]))
+     ByteArrayInputStream]
+    [java.util.concurrent
+     TimeoutException]))
 
 (netty/leak-detector-level! :paranoid)
 
@@ -156,6 +158,11 @@
                       {:body words
                        :socket-timeout 2000}))]
         (is (= (.replace ^String words "\n" "") (bs/to-string body)))))))
+
+(deftest test-connection-timeout
+  (with-handler basic-handler
+    (is (thrown? TimeoutException @(http/get "http://8.8.8.8"
+                                     {:connection-timeout 2})))))
 
 ;;;
 


### PR DESCRIPTION
I've added support for connection and request timeouts to `http/request`. In this branch there are now three timeouts:

* the existing `socket-timeout`, which limits pool generation time
* `connection-timeout`, which limits time to establish a connection post pool-generation
* `request-timeout`, which limits time for response arrival post connection-establishment

I added these because I was getting deferreds that never yielded a value for unavailable hosts, and I couldn't add a "hard" cumulative request timeout via middleware (without violating the pool contract).

In the cases of connection and request timeouts, I dispose the pooled connection because we won't know when data might be coming back from the server. I wasn't sure if there was a more intelligent way to handle this.

Additionally I've introduced reporting of a `:socket-time` separate from `:connection-time` which you may want to use.

I was also wondering if `socket-timeout` should possibly be renamed to something like `pool-timeout`? Since "socket timeout" typically refers to a limit on the amount of time without data flowing over the socket.

Let me know if there are any adjustments I can make.