### PR TITLE
On TCP Client, wrap-future blocks eternally after Server shutdown.

### DIFF
--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -103,7 +103,14 @@
 
        :channel-read
        ([_ ctx msg]
-          (netty/put! (.channel ctx) in msg)))]))
+          (netty/put! (.channel ctx) in msg))
+
+       :close
+       ([_ ctx promise]
+          (.close ctx promise)
+          ;; 'finally' block for realizing Deferred always.
+          (when-not (d/realized? d)
+            (d/error! d (IllegalStateException. "Can not connect.")))))]))
 
 (defn client
   "Given a host and port, returns a deferred which yields a duplex stream that can be used
@@ -122,16 +129,22 @@
     :or {bootstrap-transform identity}
     :as options}]
   (let [[s handler] (client-channel-handler options)]
-    (netty/create-client
-      (fn [^ChannelPipeline pipeline]
-        (.addLast pipeline "handler" ^ChannelHandler handler)
-        (when pipeline-transform
-          (pipeline-transform pipeline)))
-      (when ssl?
-        (if insecure?
-          (netty/insecure-ssl-client-context)
-          (netty/ssl-client-context)))
-      bootstrap-transform
-      (or remote-address (InetSocketAddress. ^String host (int port)))
-      local-address)
+    (-> (netty/create-client
+          (fn [^ChannelPipeline pipeline]
+            (.addLast pipeline "handler" ^ChannelHandler handler)
+            (when pipeline-transform
+              (pipeline-transform pipeline)))
+          (when ssl?
+            (if insecure?
+              (netty/insecure-ssl-client-context)
+              (netty/ssl-client-context)))
+          bootstrap-transform
+          (or remote-address (InetSocketAddress. ^String host (int port)))
+          local-address)
+        ;; netty/create-client returns a deferred object and the deferred might hold an exception on processing.
+        ;; the error must be propagated into the deferred 's'. Users can not handle
+        ;; the error without the propagation.
+        (d/catch
+          (fn [e]
+            (d/error! s e))))
     s))


### PR DESCRIPTION
# Description of problem

If you do next actions on tcp client:
- The connected server suddenly shutdowned and not recovered
- Create a new client with tcp/client and call stream/put! on it.
- Dereference the deferred object returned by stream/put!

Then the deref operation never return, because

- Netty doesn't call 'caught-exception' handler when .connect throws an Exception
 See https://github.com/netty/netty/issues/2438
The above article is about Netty 5, but Netty 4 works in the same mannar.
ConnectException must be handled in ChannelFuture,

Since caught-exception doesn't be called, client-channel-handler (see line 79 of tcp.clj) never deliver value to a Deferred, then dereferencing the Deferred never return (eternally blocked).

# Reproduction

Open 2 REPL, one for a server, one for a client.
On Server REPL, type as following. (all ;; commented line describes returned value)

```clojure
(require '(aleph [tcp :as tcp]))
;; nil
(require '(manifold [stream :as s]))
;; nil
(defn echo-handler [s info] (s/connect s s))
;; #'user/echo-handler
(tcp/start-server echo-handler {:port 10001})
;; #<netty$start_server$reify__6211 aleph.netty$start_server$reify__6211@50f113a0>
```

A TCP Echo Server is started. Then type on Client REPL as following.

```clojure
(require '(aleph [tcp :as tcp]))
;; nil
(require '(manifold [stream :as s]))
;; nil
(def client (tcp/client {:host "localhost", :port 10001}))
;; #'user/client
@(s/put! @client "Test")
;; true
@(s/take! @client)
;; #<SimpleLeakAwareByteBuf SimpleLeakAwareByteBuf(UnpooledUnsafeDirectByteBuf(ridx: 0, widx: 4, cap: 1024))>
```

Works fine. Then stop the Server REPL.
And type on Client REPL as following.

```clojure
(def client (tcp/client {:host "localhost", :port 10001})) ;recreate client.
;; #'user/client
@(s/put! @client "Test")
```

The last @(s/put! ...) never returns.
If you merge my patch, the last command will be shown like:

```clojure
@(s/put! @client "Test")
;;
;; ConnectException Connection refused: localhost/127.0.0.1:10001  sun.nio.ch.SocketChannelImpl.checkConnect (SocketChannelImpl.java:-2)
```

The exception thrown in ChannelFuture is propagated into Deferred, so the Exception is thrown at deref.

## IMPLEMENTATION NOTE

- With this patch, wrap-future never returns (d/success! false) when the ChannelFuture has fail, instead returning false, it returns (d/error! ex) with thrown exception.

- client-channel-handler must deliver a value to Deferred always for avoiding accidental block. So the handler should have safe-guard as a pseudo-finally block. I think :close handler is suitable for the purpose because the handler function always be called if any (not handled) Exception occurred. So I put :close on client-channel-handler newly and delivered a value to deferred if the deferred doesn't have any value.

- ConnectException is occurred in the deferred created by (netty/create-client), not a deferred returned as a result of (tcp/client). So we must propagate the error held by the deferred of (netty/create-client) into the deferred of (tcp/client). I put (deferred/catch) block at last of (netty/create-client).
