### PR TITLE
Fix bug in HeaderMap's keys implementation

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -96,7 +96,7 @@
       (set/union
         (set (map str/lower-case (.names headers)))
         (set (keys added)))
-      (set (keys removed))))
+      (set removed)))
   (assoc [_ k v]
     (HeaderMap.
       headers

--- a/test/aleph/http/core_test.clj
+++ b/test/aleph/http/core_test.clj
@@ -1,0 +1,18 @@
+(ns aleph.http.core-test
+  (:use
+   [clojure test])
+  (:require
+   [aleph.http.core :as core])
+  (:import
+   [io.netty.handler.codec.http
+    DefaultHttpRequest]))
+
+(deftest test-HeaderMap-keys
+  (let [^DefaultHttpRequest req (core/ring-request->netty-request
+                                 {:uri "http://example.com"
+                                  :request-method "get"
+                                  :headers {"Accept" "text/html"
+                                            "Authorization" "Basic narfdorfle"}})
+        map (core/headers->map (.headers req))
+        dissoc-map (dissoc map "authorization")]
+    (is (= #{"accept"}  (-> dissoc-map keys set)))))


### PR DESCRIPTION
The sequence `(keys (dissoc header-map "some-key"))` threw an exception because `removed` was a set, and not (as the old code seems to assume) a map.