### PR TITLE
Fix docstring formatting

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -32,9 +32,9 @@
    | `request-buffer-size` | the maximum body size, in bytes, which the server will allow to accumulate before invoking the handler, defaults to `16384`.  This does *not* represent the maximum size request the server can handle (which is unbounded), and is only a means of maximizing performance.
    | `raw-stream?` | if `true`, bodies of requests will not be buffered at all, and will be represented as Manifold streams of `io.netty.buffer.ByteBuf` objects rather than as an `InputStream`.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `rejected-handler` | a spillover request-handler which is invoked when the executor's queue is full, and the request cannot be processed.  Defaults to a `503` response.
-  | `max-initial-line-length` | the maximum characters that can be in the initial line of the request, defaults to `4096`
-  | `max-header-size` | the maximum characters that can be in a single header entry of a request, defaults to `8192`
-  | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed request, defaults to `8192`"
+   | `max-initial-line-length` | the maximum characters that can be in the initial line of the request, defaults to `4096`
+   | `max-header-size` | the maximum characters that can be in a single header entry of a request, defaults to `8192`
+   | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed request, defaults to `8192`"
   [handler
    {:keys [port socket-address executor raw-stream? bootstrap-transform pipeline-transform ssl-context request-buffer-size shutdown-executor? rejected-handler]
     :as options}]
@@ -95,8 +95,8 @@
    | `response-buffer-size` | the amount of the response, in bytes, that is buffered before the request returns, defaults to `65536`.  This does *not* represent the maximum size response that the client can handle (which is unbounded), and is only a means of maximizing performance.
    | `keep-alive?` | if `true`, attempts to reuse connections for multiple requests, defaults to `true`.
    | `raw-stream?` | if `true`, bodies of respnoses will not be buffered at all, and represented as Manifold streams of `io.netty.buffer.ByteBuf` objects rather than as an `InputStream`.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
-  | `max-header-size` | the maximum characters that can be in a single header entry of a response, defaults to `8192`
-  | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed response, defaults to `8192`"
+   | `max-header-size` | the maximum characters that can be in a single header entry of a response, defaults to `8192`
+   | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed response, defaults to `8192`"
   [{:keys [connections-per-host
            total-connections
            target-utilization


### PR DESCRIPTION
Minor cosmetic annoyance, fixes incorrect docstring formatting for: 
- http://ideolalia.com/aleph/aleph.http.html#var-connection-pool
- http://ideolalia.com/aleph/aleph.http.html#var-start-server
 