### PR TITLE
HTTP client can't make requests to URLs with illegal characters

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -12,6 +12,7 @@
      IOException]
     [java.net
      URI
+     URL
      InetSocketAddress]
     [io.netty.buffer
      ByteBuf
@@ -55,7 +56,7 @@
 (let [no-url (fn [req]
                (URI.
                  (name (or (:scheme req) :http))
-                 "nil"
+                 nil
                  (:host req)
                  (or (:port req) -1)
                  nil
@@ -64,9 +65,9 @@
 
   (defn req->domain [req]
     (if-let [url (:url req)]
-      (let [^URI uri (URI. url)]
+      (let [^URL uri (URL. url)]
         (URI.
-          (.getScheme uri)
+          (.getProtocol uri)
           nil
           (.getHost uri)
           (.getPort uri)

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -206,6 +206,13 @@
                        :socket-timeout 1e4}))]
         (is (= (.replace ^String words "\n" "") (bs/to-string body)))))))
 
+(deftest test-illegal-character-in-url
+  (with-handler hello-handler
+    (is (= "hello"
+           (-> @(http/get "http://localhost:8080/?param=illegal character")
+               :body
+               bs/to-string)))))
+
 (deftest test-connection-timeout
   (with-handler basic-handler
     (is (thrown? TimeoutException


### PR DESCRIPTION
Default request middleware encodes illegal characters (via [decorate-url](https://github.com/ztellman/aleph/blob/df1cee3c4233c05fb27af62e9e2844bf453c70a9/src/aleph/http/client_middleware.clj#L406)), but the problem is URL is actually parsed and validated before the middleware gets applied to [obtain a domain](https://github.com/ztellman/aleph/blob/df1cee3c4233c05fb27af62e9e2844bf453c70a9/src/aleph/http.clj#L196) ([parsing/validation is happening inside of `java.net.URI`](https://github.com/ztellman/aleph/blob/df1cee3c4233c05fb27af62e9e2844bf453c70a9/src/aleph/http/client.clj#L67)):

```
(require '[aleph.http :as http])
@(http/get "https://google.com/?q=test query")

Unhandled java.net.URISyntaxException
   Illegal character in query at index 26: https://google.com/?q=test query

                      URI.java: 2848  java.net.URI$Parser/fail
                      URI.java: 3021  java.net.URI$Parser/checkChars
                      URI.java: 3111  java.net.URI$Parser/parseHierarchical
                      URI.java: 3053  java.net.URI$Parser/parse
                      URI.java:  588  java.net.URI/<init>
                          REPL:    1  aleph.http.client/req->domain/fn/fn
                          REPL:    1  aleph.http.client/req->domain/fn
                          REPL:    1  aleph.http.client/req->domain
                      http.clj:  196  aleph.http/eval21287/request/fn
                      http.clj:  194  aleph.http/eval21287/request
                      http.clj:  271  aleph.http/req
                      http.clj:  268  aleph.http/req
                      AFn.java:  156  clojure.lang.AFn/applyToHelper
                      AFn.java:  144  clojure.lang.AFn/applyTo
                      core.clj:  626  clojure.core/apply
                      core.clj: 2468  clojure.core/partial/fn
                   RestFn.java:  408  clojure.lang.RestFn/invoke
                          REPL:    1  user/eval21643
                 Compiler.java: 6703  clojure.lang.Compiler/eval
                 Compiler.java: 6666  clojure.lang.Compiler/eval
                      core.clj: 2927  clojure.core/eval
                      main.clj:  239  clojure.main/repl/read-eval-print/fn
                      main.clj:  239  clojure.main/repl/read-eval-print
                      main.clj:  257  clojure.main/repl/fn
                      main.clj:  257  clojure.main/repl
                   RestFn.java: 1523  clojure.lang.RestFn/invoke
        interruptible_eval.clj:   72  clojure.tools.nrepl.middleware.interruptible-eval/evaluate/fn
                      AFn.java:  152  clojure.lang.AFn/applyToHelper
                      AFn.java:  144  clojure.lang.AFn/applyTo
                      core.clj:  624  clojure.core/apply
                      core.clj: 1862  clojure.core/with-bindings*
                   RestFn.java:  425  clojure.lang.RestFn/invoke
        interruptible_eval.clj:   56  clojure.tools.nrepl.middleware.interruptible-eval/evaluate
        interruptible_eval.clj:  191  clojure.tools.nrepl.middleware.interruptible-eval/interruptible-eval/fn/fn
        interruptible_eval.clj:  159  clojure.tools.nrepl.middleware.interruptible-eval/run-next/fn
                      AFn.java:   22  clojure.lang.AFn/run
       ThreadPoolExecutor.java: 1142  java.util.concurrent.ThreadPoolExecutor/runWorker
       ThreadPoolExecutor.java:  617  java.util.concurrent.ThreadPoolExecutor$Worker/run
                   Thread.java:  745  java.lang.Thread/run
```

It's also not possible to reuse the default middleware as an explicit middleware for `req` (something like `(http/get "https://google.com/?q=test query" {:middleware aleph.http.client-middleware/wrap-request})`) because it adds `:server-name` and `:server-port` keys to the request while `aleph.http.client/req->domain` expects `:host` and `:port`.

The simplest possible fix is provided, but I'm not sure whether it's ok from `aleph`'s architecture point of view :smile: