### PR TITLE
Upgrade netty to 4.1.0.Beta6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}
   :license {:name "MIT License"}
   :dependencies [[org.clojure/tools.logging "0.3.1" :exclusions [org.clojure/clojure]]
-                 [io.netty/netty-all "4.1.0.Beta5"]
+                 [io.netty/netty-all "4.1.0.Beta6"]
                  [manifold "0.1.1-SNAPSHOT"]
                  [byte-streams "0.2.1-SNAPSHOT"]
                  [potemkin "0.4.1"]]


### PR DESCRIPTION
Version 4.1.0.Beta6 of Netty fixes the issue https://github.com/netty/netty/issues/3490 which happens when deploying on EC2. This is the Netty milestone showing the issue fixed on this version https://github.com/netty/netty/issues?utf8=%E2%9C%93&q=milestone%3A4.1.0.Beta6+is%3Aclosed+3490

For completeness, the error when running on EC2 is:

    Sep 11, 2015 1:09:48 PM io.netty.channel.DefaultChannelId defaultMachineId
    WARNING: Failed to find a usable hardware address from the network interfaces; using random bytes: 61:d2:d5:ee:5e:95:a6:e2

Another person has mentioned this problem, see http://stackoverflow.com/questions/32302515/failed-to-find-a-usable-hardware-address-from-the-network-interfaces