### PR TITLE
Do not generate Content-Length headers on 1xx and 204 responses

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -306,7 +306,12 @@
   (let [body (if body
                (DefaultLastHttpContent. (netty/to-byte-buf ch body))
                empty-last-content)]
-    (HttpHeaders/setContentLength msg (-> ^HttpContent body .content .readableBytes))
+    (let [code (-> msg .getStatus .code)]
+      (cond
+        (<= 100 code 199) nil
+        (= 204 code) nil
+        :else
+        (HttpHeaders/setContentLength msg (-> ^HttpContent body .content .readableBytes))))
     (netty/write ch msg)
     (netty/write-and-flush ch body)))
 

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -307,15 +307,10 @@
                (DefaultLastHttpContent. (netty/to-byte-buf ch body))
                empty-last-content)
         length (-> ^HttpContent body .content .readableBytes)]
-    (if (instance? DefaultHttpResponse msg)
+    (if (instance? HttpResponse msg)
       (let [code (-> msg .getStatus .code)]
-        (cond
-          (<= 100 code 199) nil
-          (= 204 code) nil
-          :else
-          (HttpHeaders/setContentLength
-           msg
-           length)))
+        (when-not (or (<= 100 code 199) (= 204 code))
+          (HttpHeaders/setContentLength msg length)))
       (HttpHeaders/setContentLength msg length))
     (netty/write ch msg)
     (netty/write-and-flush ch body)))


### PR DESCRIPTION
Consider this example, running with the current git version https://gist.github.com/Leonidas-from-XIV/c4a6fb02bf8cd8288f5e, where Aleph returns an invalid header value. Basically, it takes the length of the response (9), adds it as a header and then I think Netty throws the body rightfully away, without adjusting for the headers. This creates issues with HTTP clients that read this header and wait indefinitely to get these 9 bytes that will never arrive (yes, that happened to us).

The proper behaviour (returning Content-Length: 0 in 204 requests or leaving the header out) is somewhat disputed on the internet, but RFC 7230, section 3.3.2 is relatively clear about it:

> A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).

Hope this PR is of use to you, let me know if there are any changes necessary to get this in!