### PR TITLE
Make websocket-client support subprotocols and extensions

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -147,10 +147,12 @@
    |:---|:---
    | `raw-stream?` | if `true`, the connection will emit raw `io.netty.buffer.ByteBuf` objects rather than strings or byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `insecure?` | if `true`, the certificates for `wss://` will be ignored.
+   | `extensions?` | if `true`, the websocket extensions will be supported.
+   | `sub-protocols` | a string with a comma seperated list of supported sub-protocls.
    | `headers` | the headers that should be included in the handshake"
   ([url]
     (websocket-client url nil))
-  ([url {:keys [raw-stream? insecure? headers] :as options}]
+  ([url {:keys [raw-stream? insecure? sub-protocols extensions? headers] :as options}]
     (client/websocket-connection url options)))
 
 (defn websocket-connection

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -452,7 +452,7 @@
     :as options}]
   (let [uri (URI. uri)
         ssl? (= "wss" (.getScheme uri))
-        [s handler] (websocket-client-handler raw-stream? uri subprotocols extensions? headers)]
+        [s handler] (websocket-client-handler raw-stream? uri sub-protocols extensions? headers)]
 
     (assert (#{"ws" "wss"} (.getScheme uri)) "scheme must be one of 'ws' or 'wss'")
 

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -356,8 +356,8 @@
   (WebSocketClientHandshakerFactory/newHandshaker
     uri
     WebSocketVersion/V13
-    extensions?
     sub-protocols
+    extensions?
     (doto (DefaultHttpHeaders.) (http/map->headers! headers))))
 
 (defn websocket-client-handler [raw-stream? uri extensions? sub-protocols headers]

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -352,7 +352,7 @@
 (defn websocket-frame-size [^WebSocketFrame frame]
   (-> frame .content .readableBytes))
 
-(defn ^WebSocketClientHandshaker websocket-handshaker [uri extensions? sub-protocols headers]
+(defn ^WebSocketClientHandshaker websocket-handshaker [uri sub-protocols extensions? headers]
   (WebSocketClientHandshakerFactory/newHandshaker
     uri
     WebSocketVersion/V13
@@ -360,10 +360,10 @@
     extensions?
     (doto (DefaultHttpHeaders.) (http/map->headers! headers))))
 
-(defn websocket-client-handler [raw-stream? uri extensions? sub-protocols headers]
+(defn websocket-client-handler [raw-stream? uri sub-protocols extensions? headers]
   (let [d (d/deferred)
         in (atom nil)
-        handshaker (websocket-handshaker uri extensions? sub-protocols headers)]
+        handshaker (websocket-handshaker uri sub-protocols extensions? headers)]
 
     [d
 
@@ -442,17 +442,17 @@
 (defn websocket-connection
   [uri
    {:keys [raw-stream? bootstrap-transform insecure? headers local-address epoll?
-           extensions? sub-protocols]
+           sub-protocols extensions?]
     :or {bootstrap-transform identity
          keep-alive? true
          raw-stream? false
          epoll? false
-         extensions? false
-         sub-protocols nil}
+         sub-protocols nil
+         extensions? false}
     :as options}]
   (let [uri (URI. uri)
         ssl? (= "wss" (.getScheme uri))
-        [s handler] (websocket-client-handler raw-stream? uri extensions? subprotocols headers)]
+        [s handler] (websocket-client-handler raw-stream? uri subprotocols extensions? headers)]
 
     (assert (#{"ws" "wss"} (.getScheme uri)) "scheme must be one of 'ws' or 'wss'")
 


### PR DESCRIPTION
Hi,
i needed to make a fix to let websocket clients support subprotocols and extensions.
 