### PR TITLE
Fix HTTP client StringIndexOutOfBoundsException when empty query params are passed

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -313,16 +313,18 @@
     "UTF-8"))
 
 (defn generate-query-string [params & [content-type]]
-  (let [encoding (detect-charset content-type)
-        sb (StringBuffer.)]
-    (p/doit [[k v] params]
-      (let [k' (url-encode (name k) encoding)]
-        (p/doit [x (if (sequential? v) v [v])]
-          (.append sb k')
-          (.append sb "=")
-          (.append sb (url-encode (str x) encoding))
-          (.append sb "&"))))
-    (.substring sb 0 (unchecked-dec (unchecked-long (.length sb))))))
+  (if (seq params)
+    (let [encoding (detect-charset content-type)
+          sb (StringBuffer.)]
+      (p/doit [[k v] params]
+        (let [k' (url-encode (name k) encoding)]
+          (p/doit [x (if (sequential? v) v [v])]
+            (.append sb k')
+            (.append sb "=")
+            (.append sb (url-encode (str x) encoding))
+            (.append sb "&"))))
+      (.substring sb 0 (unchecked-dec (unchecked-long (.length sb)))))
+    ""))
 
 (def-decorator decorate-query-params
   [query-params req]

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -1,0 +1,8 @@
+(ns aleph.http.client-middleware-test
+  (:require [aleph.http.client-middleware :as middleware]
+            [clojure.test :as t :refer [deftest is]]))
+
+(deftest test-empty-query-string
+  (is (= "" (middleware/generate-query-string {})))
+  (is (= "" (middleware/generate-query-string {} "text/plain; charset=utf-8")))
+  (is (= "" (middleware/generate-query-string {} "text/html;charset=ISO-8859-1"))))


### PR DESCRIPTION
Related to #186

`StringIndexOutOfBoundsException` is still thrown when empty `params` map is passed to the `generate-query-string`:

```
> (require '[aleph.http.client-middleware :as ahcm])
nil
> (ahcm/generate-query-string {})
StringIndexOutOfBoundsException String index out of range: -1  java.lang.AbstractStringBuilder.substring (AbstractStringBuilder.java:908)

```