### PR TITLE
Make http example non-blocking

### DIFF
--- a/examples/src/aleph/examples/http.clj
+++ b/examples/src/aleph/examples/http.clj
@@ -3,6 +3,7 @@
     [compojure.core :as compojure :refer [GET]]
     [ring.middleware.params :as params]
     [compojure.route :as route]
+    [compojure.response :refer [Renderable]]
     [aleph.http :as http]
     [byte-streams :as bs]
     [manifold.stream :as s]
@@ -40,6 +41,15 @@
     (d/deferred)
     1000
     (hello-world-handler req)))
+
+;; Compojure will normally dereference deferreds and return the realized value.
+;; This unfortunately blocks the thread. Since aleph can accept the un-realized
+;; deferred, we extend compojure's Renderable protocol to pass the deferred
+;; through unchanged so that the thread won't be blocked.
+
+(extend-protocol Renderable
+  manifold.deferred.Deferred
+  (render [d _] d))
 
 (defn delayed-hello-world-handler
   "Alternately, we can use a [core.async](https://github.com/clojure/core.async) goroutine to


### PR DESCRIPTION
I modified the http example to have non-blocking behavior. Composure blocks on deferreds unless we extend Renderable.

The difference can be seen when benchmarking with `:executor :none`

Before:

    $ wrk -t 1 -c 250 -d 10 http://localhost:10000/delayed_hello
    Running 10s test @ http://localhost:10000/delayed_hello
      1 threads and 250 connections
      Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.05s    45.93ms   1.10s    68.75%
    Req/Sec    15.33      1.00    17.00     66.67%
      144 requests in 10.05s, 22.36KB read
      Socket errors: connect 0, read 0, write 0, timeout 112
    Requests/sec:     14.32
    Transfer/sec:      2.22KB

After:

    $ wrk -t 1 -c 250 -d 10 http://localhost:10000/delayed_hello
    Running 10s test @ http://localhost:10000/delayed_hello
      1 threads and 250 connections
      Thread Stats   Avg      Stdev     Max   +/- Stdev
        Latency     1.01s    12.00ms   1.05s    88.58%
        Req/Sec   437.40    685.35     2.38k    90.00%
      2237 requests in 10.05s, 347.35KB read
      Socket errors: connect 0, read 0, write 0, timeout 13
    Requests/sec:    222.51
    Transfer/sec:     34.55KB
