### PR TITLE
deref shutdown future instead of wrapping

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -709,7 +709,7 @@
           (close [_]
             (when on-close (on-close))
             (-> ch .close .sync)
-            (-> group .shutdownGracefully wrap-future))
+            @(.shutdownGracefully group))
           AlephServer
           (port [_]
             (-> ch .localAddress .getPort))))


### PR DESCRIPTION
The java.io.Closeable interface returns void, so the future
is never accessible otherwise.