### PR TITLE
fix for aleph server dropping WebSocket continuation frames

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -165,10 +165,11 @@
    | `raw-stream?` | if `true`, the connection will emit raw `io.netty.buffer.ByteBuf` objects rather than strings or byte-arrays.  This will minimize copying, but means that care must be taken with Netty's buffer reference counting.  Only recommended for advanced users.
    | `headers` | the headers that should be included in the handshake
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to 65536.
+   | `max-frame-size` | maximum aggregate message size, in bytes, defaults to 1048576.
    | `allow-extensions?` | if true, allows extensions to the WebSocket protocol"
   ([req]
     (websocket-connection req nil))
-  ([req {:keys [raw-stream? headers max-frame-payload allow-extensions?] :as options}]
+  ([req {:keys [raw-stream? headers max-frame-payload max-frame-size allow-extensions?] :as options}]
     (server/initialize-websocket-handler req options)))
 
 (let [maybe-timeout! (fn [d timeout] (when d (d/timeout! d timeout)))


### PR DESCRIPTION
recently ran into an issue where aleph would drop continuation frames of WebSocket messages: the handler passed to `stream/consume` wasn't being invoked with the entire message and wasn't being applied to any frames other than the first one sent by the client.

Seems like aleph could solve this by handling `ContinuationWebSocketFrame`s in `http.server/websocket-server-handler`'s `:channel-read` callback, or by inserting a `WebSocketFrameAggregator` into the channel pipeline as part of `http.server/initialize-websocket-handler`.

The first approach would require aleph to allocate and manage some temporary storage before a final frame is received, while the second approach leans on Netty having already implemented that.

With `:pipeline-transform` its possible for users to add this handler themselves without any change to aleph, but it feels like this sort of behavior should be turned on out of the box. Happy to discuss further.