### PR TITLE
Changed link to aleph.io

### DIFF
--- a/examples/src/aleph/examples/http.clj
+++ b/examples/src/aleph/examples/http.clj
@@ -17,7 +17,7 @@
 ;; [Manifold](https://github.com/ztellman/manifold) deferreds and streams.  Uses of both
 ;; will be illustrated below.
 
-;; Complete documentation for the `aleph.http` namespace can be found [here](http://ideolalia.com/aleph/aleph.http.html).
+;; Complete documentation for the `aleph.http` namespace can be found [here](http://aleph.io/aleph/http.html).
 
 (defn hello-world-handler
   "A basic Ring handler which immediately returns 'hello world'"


### PR DESCRIPTION
I think this is where that link is meant to go? Re: Issue #243 