### PR TITLE
websocket client: max-frame-payload, continuation frame support

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -153,10 +153,11 @@
    | `extensions?` | if `true`, the websocket extensions will be supported.
    | `sub-protocols` | a string with a comma seperated list of supported sub-protocols.
    | `headers` | the headers that should be included in the handshake
-   | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to 65536."
+   | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to 65536.
+   | `max-frame-size` | maximum aggregate message size, in bytes, defaults to 1048576."
   ([url]
     (websocket-client url nil))
-  ([url {:keys [raw-stream? insecure? sub-protocols extensions? headers max-frame-payload] :as options}]
+  ([url {:keys [raw-stream? insecure? sub-protocols extensions? headers max-frame-payload max-frame-size] :as options}]
     (client/websocket-connection url options)))
 
 (defn websocket-connection

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -362,18 +362,19 @@
 (defn websocket-frame-size [^WebSocketFrame frame]
   (-> frame .content .readableBytes))
 
-(defn ^WebSocketClientHandshaker websocket-handshaker [uri sub-protocols extensions? headers]
+(defn ^WebSocketClientHandshaker websocket-handshaker [uri sub-protocols extensions? headers max-frame-payload]
   (WebSocketClientHandshakerFactory/newHandshaker
     uri
     WebSocketVersion/V13
     sub-protocols
     extensions?
-    (doto (DefaultHttpHeaders.) (http/map->headers! headers))))
+    (doto (DefaultHttpHeaders.) (http/map->headers! headers))
+    max-frame-payload))
 
-(defn websocket-client-handler [raw-stream? uri sub-protocols extensions? headers]
+(defn websocket-client-handler [raw-stream? uri sub-protocols extensions? headers max-frame-payload]
   (let [d (d/deferred)
         in (atom nil)
-        handshaker (websocket-handshaker uri sub-protocols extensions? headers)]
+        handshaker (websocket-handshaker uri sub-protocols extensions? headers max-frame-payload)]
 
     [d
 
@@ -452,17 +453,18 @@
 (defn websocket-connection
   [uri
    {:keys [raw-stream? bootstrap-transform insecure? headers local-address epoll?
-           sub-protocols extensions?]
+           sub-protocols extensions? max-frame-payload]
     :or {bootstrap-transform identity
          keep-alive? true
          raw-stream? false
          epoll? false
          sub-protocols nil
-         extensions? false}
+         extensions? false
+         max-frame-payload 65536}
     :as options}]
   (let [uri (URI. uri)
         ssl? (= "wss" (.getScheme uri))
-        [s handler] (websocket-client-handler raw-stream? uri sub-protocols extensions? headers)]
+        [s handler] (websocket-client-handler raw-stream? uri sub-protocols extensions? headers max-frame-payload)]
 
     (assert (#{"ws" "wss"} (.getScheme uri)) "scheme must be one of 'ws' or 'wss'")
 


### PR DESCRIPTION
almost identical set of changes to those made on the server side to support large frame payloads and aggregating continuation frames