### PR TITLE
make PTR record lookups in UDP functionality optional

### DIFF
--- a/src/aleph/udp.clj
+++ b/src/aleph/udp.clj
@@ -23,8 +23,7 @@
      EpollDatagramChannel]))
 
 (p/def-derived-map UdpPacket [^DatagramPacket packet content]
-  :host (-> packet ^InetSocketAddress (.sender) .getHostName)
-  :port (-> packet ^InetSocketAddress (.sender) .getPort)
+  :sender (-> packet ^InetSocketAddress (.sender))
   :message content)
 
 (alter-meta! #'->UdpPacket assoc :private true)


### PR DESCRIPTION
This change maintains default behavior and backwards compatibility but allows for avoiding DNS PTR lookups per UDP packet.