### PR TITLE
Adds support for form param coercion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
                  [byte-streams "0.2.2"]
                  [potemkin "0.4.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [criterium "0.4.4"]]}}
+                                  [criterium "0.4.4"]
+                                  [cheshire "5.6.3"]]}}
   :codox {:src-dir-uri "https://github.com/ztellman/aleph/tree/master/"
           :src-linenum-anchor-prefix "L"
           :defaults {:doc/format :markdown}

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
                  [potemkin "0.4.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [criterium "0.4.4"]
-                                  [cheshire "5.6.3"]]}}
+                                  [cheshire "5.6.3"]
+                                  [com.cognitect/transit-clj "0.8.285"]]}}
   :codox {:src-dir-uri "https://github.com/ztellman/aleph/tree/master/"
           :src-linenum-anchor-prefix "L"
           :defaults {:doc/format :markdown}

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -10,6 +10,8 @@
 (deftest test-coerce-form-params
   (is (= "{\"foo\":\"bar\"}" (middleware/coerce-form-params {:content-type :json
                                                              :form-params {:foo :bar}})))
+  (is (= "[\"^ \",\"~:foo\",\"~:bar\"]" (slurp (middleware/coerce-form-params {:content-type :transit+json
+                                                                               :form-params {:foo :bar}}))))  
   (is (= "{:foo :bar}" (middleware/coerce-form-params {:content-type :edn
                                                        :form-params {:foo :bar}})))
   (is (= "foo=%3Abar" (middleware/coerce-form-params {:content-type :default

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -6,3 +6,14 @@
   (is (= "" (middleware/generate-query-string {})))
   (is (= "" (middleware/generate-query-string {} "text/plain; charset=utf-8")))
   (is (= "" (middleware/generate-query-string {} "text/html;charset=ISO-8859-1"))))
+
+(deftest test-coerce-form-params
+  (is (= "{\"foo\":\"bar\"}" (middleware/coerce-form-params {:content-type :json
+                                                             :form-params {:foo :bar}})))
+  (is (= "{:foo :bar}" (middleware/coerce-form-params {:content-type :edn
+                                                       :form-params {:foo :bar}})))
+  (is (= "foo=%3Abar" (middleware/coerce-form-params {:content-type :default
+                                                      :form-params {:foo :bar}})))
+  (is (= (middleware/coerce-form-params {:content-type :default
+                                         :form-params {:foo :bar}})
+         (middleware/coerce-form-params {:form-params {:foo :bar}}))))


### PR DESCRIPTION
As discussed in ztellman/aleph#257, here you will find a PR that integrates clj-http's support for json, edn and transit form param coercion.