### PR TITLE
Fix memory leak with binary websocket frames (in websocket clients)

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -444,10 +444,10 @@
                (netty/put! ch @in (.text ^TextWebSocketFrame msg))
 
                (instance? BinaryWebSocketFrame msg)
-               (let [frame (netty/acquire (.content ^BinaryWebSocketFrame msg))]
+               (let [frame (.content ^BinaryWebSocketFrame msg)]
                  (netty/put! ch @in
                    (if raw-stream?
-                     frame
+                     (netty/acquire frame)
                      (netty/buf->array frame))))
 
                (instance? PongWebSocketFrame msg)


### PR DESCRIPTION
The same fix as in https://github.com/ztellman/aleph/pull/302 but for websocket clients instead of websocket servers.