### PR TITLE
Fix example extending compojure Renderable with correct IDeferred interface

### DIFF
--- a/examples/src/aleph/examples/http.clj
+++ b/examples/src/aleph/examples/http.clj
@@ -52,7 +52,7 @@
 ;; deferred, we extend Compojure's `Renderable` protocol to pass the deferred
 ;; through unchanged so it can be handled asynchronously.
 (extend-protocol Renderable
-  manifold.deferred.Deferred
+  manifold.deferred.IDeferred
   (render [d _] d))
 
 (defn delayed-hello-world-handler


### PR DESCRIPTION
In the compojure example of delayed-handler, manifold.deferred.Deferred doesn't exist. Changed to IDeferred.