### PR TITLE
Enable server side compression

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -35,7 +35,8 @@
    | `rejected-handler` | a spillover request-handler which is invoked when the executor's queue is full, and the request cannot be processed.  Defaults to a `503` response.
    | `max-initial-line-length` | the maximum characters that can be in the initial line of the request, defaults to `4096`
    | `max-header-size` | the maximum characters that can be in a single header entry of a request, defaults to `8192`
-   | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed request, defaults to `8192`"
+   | `max-chunk-size` | the maximum characters that can be in a single chunk of a streamed request, defaults to `8192`
+   | `compression?` | when `true` enables http compression, defaults to `false`"
   [handler
    {:keys [port socket-address executor raw-stream? bootstrap-transform pipeline-transform ssl-context request-buffer-size shutdown-executor? rejected-handler]
     :as options}]


### PR DESCRIPTION
Hi!

I'm am trying to learn more about aleph and netty but it's the first time I'm looking into that. So this might be more of a request for comments - if time allows - about my clojure code. I essentially saw #272 as a low hanging fruit that could help me understand the it.

Right now it still feels kind of hacky. Do you see obvious areas of improvement? Could I somehow combine the `compression?` key with the `pipeline-transform` without loosing the possibility to configure compression?

Daniel