### PR TITLE
Support :multipart in HTTP clients requests

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -315,12 +315,11 @@
                 (when-not (.get (.headers req') "Connection")
                   (HttpHeaders/setKeepAlive req' keep-alive?))
 
-                ;; TODO: uncomment this once the multipart implementation is validated
-                (let [body (if-let [parts (comment (get req :multipart))]
+                (let [body (if-let [parts (get req :multipart)]
                              (multipart/encode-body parts)
                              (get req :body))]
                   (netty/safe-execute ch
-                    (http/send-message ch true ssl? req' body))))
+                                      (http/send-message ch true ssl? req' body))))
 
               ;; this will usually happen because of a malformed request
               (catch Throwable e

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -36,11 +36,12 @@
                (when file?
                  (URLConnection/guessContentTypeFromName (.getName ^File content))))
         ;; populate file name when working with file object
-        filename (or name (when file? (.getName ^File content)))]
-    {:part-name part-name
+        filename (or name (when file? (.getName ^File content)))
+        ;; use "name" as a part name when the last is not provided
+        part-name-to-use (or part-name name filename)]
+    {:part-name part-name-to-use
      :content (bs/to-byte-buffer content)
-     ;; do not need to specify charset when sending file
-     :mime-type (mime-type-descriptor mt (when-not file? charset))
+     :mime-type (mime-type-descriptor mt charset)
      :transfer-encoding transfer-encoding
      :name filename}))
 

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -29,56 +29,80 @@
 
 (defn populate-part
   "Generates a part map of the appropriate format"
-  [{:keys [name content mime-type charset transfer-encoding] :or {transfer-encoding :quoted-printable}}]
+  [{:keys [name content mime-type charset transfer-encoding filename]}]
   (let [mt (or mime-type
              (when (instance? File content)
                (URLConnection/guessContentTypeFromName (.getName ^File content))))]
-    {:name name :content (bs/to-byte-buffer content)
+    {:name name
+     :content (bs/to-byte-buffer content)
      :mime-type (mime-type-descriptor mt charset)
-     :transfer-encoding transfer-encoding}))
+     :transfer-encoding transfer-encoding
+     :filename filename}))
 
-(defn part-headers [name mime-type transfer-encoding]
-  (let [te (cc/name transfer-encoding)
-        cd (str "content-disposition: form-data; name=\"" (encode name :qp) \newline)
+;; Omit "content-transfer-encoding" when not provided
+;;
+;; RFC 2388, section 3:
+;; Each part may be encoded and the "content-transfer-encoding" header
+;; supplied if the value of that part does not conform to the default
+;; encoding.
+;;
+;; Include local filename when provided. It might be required by a server
+;; when dealing with users' file uploads.
+;;
+;; RFC 2388, section 4.4:
+;; The original local file name may be supplied as well...
+(defn part-headers [^String name ^String mime-type transfer-encoding filename]
+  (let [te (when transfer-encoding (cc/name transfer-encoding))
+        cd (str "content-disposition: form-data; name=\"" (encode name :qp) "\""
+                (when filename (str "; filename=\"" (encode filename :qp) "\""))
+                \newline)
         ct (str "content-type: " mime-type \newline)
-        cte (str "content-transfer-encoding: " te "\n\n")
+        cte (if-not te "" (str "content-transfer-encoding: " te \newline \newline))
         lcd (.length cd)
         lct (.length ct)
         lcte (.length cte)
         size (+ lcd lct lcte)
         buf (ByteBuffer/allocate size)]
     (doto buf
-      (.put 0 (bs/to-byte-buffer cd))
-      (.put lcd (bs/to-byte-buffer ct))
-      (.put (+ lcd lct) (bs/to-byte-buffer cte)))))
+      (.put (bs/to-byte-buffer cd))
+      (.put (bs/to-byte-buffer ct))
+      (.put (bs/to-byte-buffer cte))
+      (.flip))))
 
 (defn encode-part
   "Generates the byte representation of a part for the bytebuffer"
-  [{:keys [name content mime-type charset transfer-encoding] :as part}]
-  ;; encode name, content`
-  (let [headers (part-headers name mime-type transfer-encoding)
-        body (encode content transfer-encoding)
-        header-len (.length ^String headers)
-        size (+ header-len (.length ^String body))
+  [{:keys [name content mime-type charset transfer-encoding filename] :as part}]
+  (let [headers (part-headers name mime-type transfer-encoding filename)
+        body (bs/to-byte-buffer (encode content (or transfer-encoding :qp)))
+        header-len (.limit ^ByteBuffer headers)
+        size (+ header-len (.limit ^ByteBuffer body))
         buf (ByteBuffer/allocate size)]
     (doto buf
-      (.put 0 headers)
-      (.put header-len body))))
+      (.put ^ByteBuffer headers)
+      (.put ^ByteBuffer body))))
+
+(def ^ByteBuffer newline-bytes-buffer (bs/to-byte-buffer "\n"))
+(def ^ByteBuffer dashes-bytes-buffer (bs/to-byte-buffer "--"))
 
 (defn encode-body
   ([parts]
-    (encode-body (boundary) parts))
+   (encode-body (boundary) parts))
   ([^String boundary parts]
-    (let [b (bs/to-byte-buffer boundary)
-          b-len (+ 2 (.length boundary))
-          ps (map #(-> % populate-part encode-part) parts)
-          boundaries-len (* (inc (count parts)) b-len)
-          part-len (reduce (fn [acc ^String p] (+ acc (.length p))) 0 ps)
-          buf (ByteBuffer/allocate (+ boundaries-len part-len))]
-      (.put buf 0 b)
-      (reduce (fn [idx part]
-                (let [p-len (.length ^String part)]
-                  (.put buf idx part)
-                  (.put buf (+ idx part-len) b)
-                  (+ idx part-len b-len))) b-len ps)
-      buf)))
+   (let [b (bs/to-byte-buffer (str "--" boundary))
+         b-len (+ 5 (.length boundary))
+         ps (map #(-> % populate-part encode-part) parts)
+         boundaries-len (* (inc (count parts)) b-len)
+         part-len (reduce (fn [acc ^ByteBuffer p] (+ acc (.limit p))) 0 ps)
+         buf (ByteBuffer/allocate (+ 2 boundaries-len part-len))]
+     (.put buf b)
+     (doseq [^ByteBuffer part ps]
+       (.put buf newline-bytes-buffer)
+       (.flip part)
+       (.put buf part)
+       (.put buf newline-bytes-buffer)
+       (.put buf newline-bytes-buffer)
+       (.flip b)
+       (.put buf b))
+     (.put buf dashes-bytes-buffer)
+     (.flip buf)
+     (bs/to-byte-array buf))))

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -79,10 +79,8 @@
         buf (ByteBuffer/allocate size)]
     (doto buf
       (.put ^ByteBuffer headers)
-      (.put ^ByteBuffer body))))
-
-(def ^ByteBuffer newline-bytes-buffer (bs/to-byte-buffer "\n"))
-(def ^ByteBuffer dashes-bytes-buffer (bs/to-byte-buffer "--"))
+      (.put ^ByteBuffer body)
+      (.flip))))
 
 (defn encode-body
   ([parts]
@@ -96,13 +94,12 @@
          buf (ByteBuffer/allocate (+ 2 boundaries-len part-len))]
      (.put buf b)
      (doseq [^ByteBuffer part ps]
-       (.put buf newline-bytes-buffer)
-       (.flip part)
+       (.put buf (bs/to-byte-buffer "\n"))
        (.put buf part)
-       (.put buf newline-bytes-buffer)
-       (.put buf newline-bytes-buffer)
+       (.put buf (bs/to-byte-buffer "\n"))
+       (.put buf (bs/to-byte-buffer "\n"))
        (.flip b)
        (.put buf b))
-     (.put buf dashes-bytes-buffer)
+     (.put buf (bs/to-byte-buffer "--"))
      (.flip buf)
      (bs/to-byte-array buf))))

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -27,7 +27,6 @@
     (when encoding
       (str ";charset=" encoding))))
 
-;; Omit "charset=*" when working with files
 (defn populate-part
   "Generates a part map of the appropriate format"
   [{:keys [part-name content mime-type charset transfer-encoding name]}]

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -1,0 +1,31 @@
+(ns aleph.http.multipart-test
+  (:use
+   [clojure test])
+  (:require
+   [aleph.http.multipart :as mp]
+   [byte-streams :as bs]))
+
+(deftest test-multipart-builder
+  (let [body (mp/encode-body [{:name "part1"
+                               :content "content1"
+                               :charset "UTF-8"}
+                              {:name "part2"
+                               :content "content2"
+                               :charset "ascii"
+                               :mime-type "application/json"
+                               :filename "content2.pdf"}])
+        body-str (bs/to-string body)]
+    (is (.contains body-str "name=\"part1\""))
+    (is (.contains body-str "name=\"part2\""))
+    (is (.contains body-str "content1"))
+    (is (.contains body-str "content2"))
+    (is (.contains body-str "content-disposition: form-data;"))
+    (is (.contains body-str "content-type: application/octet-stream;charset=UTF-8"))
+    (is (.contains body-str "content-type: application/json;charset=ascii"))
+    (is (.contains body-str "filename=\"content2.pdf\""))))
+
+(deftest test-custom-boundary
+  (let [b (mp/boundary)
+        body (mp/encode-body b [{:name "part1" :content "content1"}])
+        body-str (bs/to-string body)]
+    (is (.endsWith body-str (str b "--")))))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -3,29 +3,77 @@
    [clojure test])
   (:require
    [aleph.http.multipart :as mp]
-   [byte-streams :as bs]))
+   [byte-streams :as bs])
+  (:import
+   [java.io
+    File]))
+
+(def file-to-send (File. (str (System/getProperty "user.dir") "/test/file.txt")))
 
 (deftest test-multipart-builder
   (let [body (mp/encode-body [{:part-name "part1"
                                :content "content1"
                                :charset "UTF-8"}
                               {:part-name "part2"
-                               :content "content2"
-                               :charset "ISO-8859-1"
-                               :mime-type "application/json"
-                               :name "content2.pdf"}])
+                               :content "content2"}
+                              {:part-name "part3"
+                               :content "content3"
+                               :mime-type "application/json"}
+                              {:part-name "part4"
+                               :content "content4"
+                               :mime-type "application/xml"
+                               :charset "ISO-8859-1"}
+                              {:part-name "part5"
+                               :content "content5"
+                               :name "content5.pdf"}
+                              {:name "part6"
+                               :content "content6"}])
         body-str (bs/to-string body)]
     (is (.contains body-str "name=\"part1\""))
     (is (.contains body-str "name=\"part2\""))
+    (is (.contains body-str "name=\"part3\""))
+    (is (.contains body-str "name=\"part4\""))
+    (is (.contains body-str "name=\"part5\""))
+    (is (.contains body-str "name=\"part6\""))
     (is (.contains body-str "content1"))
     (is (.contains body-str "content2"))
     (is (.contains body-str "content-disposition: form-data;"))
+    ;; default mime-type
     (is (.contains body-str "content-type: application/octet-stream;charset=UTF-8"))
-    (is (.contains body-str "content-type: application/json;charset=ISO-8859-1"))
-    (is (.contains body-str "filename=\"content2.pdf\""))))
+    ;; omitting charset
+    (is (.contains body-str "content-type: application/json\n"))
+    ;; mime-type + charset
+    (is (.contains body-str "content-type: application/xml;charset=ISO-8859-1"))
+    ;; filename header
+    (is (.contains body-str "filename=\"content5.pdf\""))))
 
 (deftest test-custom-boundary
   (let [b (mp/boundary)
         body (mp/encode-body b [{:part-name "part1" :content "content1"}])
         body-str (bs/to-string body)]
     (is (.endsWith body-str (str b "--")))))
+
+(deftest test-content-as-file
+  (let [body (mp/encode-body [{:part-name "part1"
+                               :content file-to-send}
+                              {:part-name "part2"
+                               :mime-type "application/png"
+                               :content file-to-send}
+                              {:part-name "part3"
+                               :name "text-file-to-send.txt"
+                               :content file-to-send}
+                              {:part-name "part4"
+                               :charset "UTF-8"
+                               :content file-to-send}
+                              {:content file-to-send}])
+        body-str (bs/to-string body)]
+    (is (.contains body-str "name=\"part1\""))
+    (is (.contains body-str "name=\"part2\""))
+    (is (.contains body-str "name=\"part3\""))
+    (is (.contains body-str "name=\"part4\""))
+    (is (.contains body-str "name=\"file.txt\""))
+    (is (.contains body-str "filename=\"file.txt\""))
+    (is (.contains body-str "filename=\"text-file-to-send.txt\""))
+    (is (.contains body-str "content-type: text/plain\n"))
+    (is (.contains body-str "content-type: text/plain;charset=UTF-8\n"))
+    (is (.contains body-str "content-type: application/png\n"))))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -6,14 +6,14 @@
    [byte-streams :as bs]))
 
 (deftest test-multipart-builder
-  (let [body (mp/encode-body [{:name "part1"
+  (let [body (mp/encode-body [{:part-name "part1"
                                :content "content1"
                                :charset "UTF-8"}
-                              {:name "part2"
+                              {:part-name "part2"
                                :content "content2"
-                               :charset "ascii"
+                               :charset "ISO-8859-1"
                                :mime-type "application/json"
-                               :filename "content2.pdf"}])
+                               :name "content2.pdf"}])
         body-str (bs/to-string body)]
     (is (.contains body-str "name=\"part1\""))
     (is (.contains body-str "name=\"part2\""))
@@ -21,11 +21,11 @@
     (is (.contains body-str "content2"))
     (is (.contains body-str "content-disposition: form-data;"))
     (is (.contains body-str "content-type: application/octet-stream;charset=UTF-8"))
-    (is (.contains body-str "content-type: application/json;charset=ascii"))
+    (is (.contains body-str "content-type: application/json;charset=ISO-8859-1"))
     (is (.contains body-str "filename=\"content2.pdf\""))))
 
 (deftest test-custom-boundary
   (let [b (mp/boundary)
-        body (mp/encode-body b [{:name "part1" :content "content1"}])
+        body (mp/encode-body b [{:part-name "part1" :content "content1"}])
         body-str (bs/to-string body)]
     (is (.endsWith body-str (str b "--")))))


### PR DESCRIPTION
@ztellman Covering issue: https://github.com/ztellman/aleph/issues/159

Unit tests are included. 

API is slightly extended from the previous implementation to provided better compatibility with `clj-http` client.