### PR TITLE
Add IDN URLs support to HTTP client

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -60,8 +60,7 @@
                (URI.
                  (name (or (:scheme req) :http))
                  nil
-                 (when-some [host (or (:host req) (:server-name req))]
-                   (IDN/toASCII host))
+                 (some-> (or (:host req) (:server-name req)) IDN/toASCII)
                  (or (:port req) (:server-port req) -1)
                  nil
                  nil

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -14,7 +14,8 @@
     [java.net
      URI
      URL
-     InetSocketAddress]
+     InetSocketAddress
+     IDN]
     [io.netty.buffer
      ByteBuf
      Unpooled]
@@ -59,19 +60,20 @@
                (URI.
                  (name (or (:scheme req) :http))
                  nil
-                 (or (:host req) (:server-name req))
+                 (when-some [host (or (:host req) (:server-name req))]
+                   (IDN/toASCII host))
                  (or (:port req) (:server-port req) -1)
                  nil
                  nil
                  nil))]
 
-  (defn req->domain [req]
+  (defn ^java.net.URI req->domain [req]
     (if-let [url (:url req)]
       (let [^URL uri (URL. url)]
         (URI.
           (.getProtocol uri)
           nil
-          (.getHost uri)
+          (IDN/toASCII (.getHost uri))
           (.getPort uri)
           nil
           nil

--- a/test/aleph/http/client_test.clj
+++ b/test/aleph/http/client_test.clj
@@ -1,0 +1,43 @@
+(ns aleph.http.client-test
+  (:require [aleph.http.client :as client]
+            [clojure.test :as t :refer [deftest is testing]]))
+
+(deftest test-domain-extracting
+  (testing "ASCII domain is extracted from URL as is."
+    (let [uri (client/req->domain {:url "https://domainname.com:80"})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "domainname.com" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "ASCII domain is extracted from request host as is."
+    (let [uri (client/req->domain {:scheme "https"
+                                   :host "domainname.com"
+                                   :port 80})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "domainname.com" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "ASCII domain is extracted from request server name as is."
+    (let [uri (client/req->domain {:scheme "https"
+                                   :server-name "domainname.com"
+                                   :port 80})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "domainname.com" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "IDN domain in URL is translated to ASCII."
+    (let [uri (client/req->domain {:url "https://名がドメイン.com:80"})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "xn--v8jxj3d1dzdz08w.com" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "IDN domain from request host is translated to ASCII."
+    (let [uri (client/req->domain {:scheme "https"
+                                   :host "名がドメイン.com"
+                                   :port 80})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "xn--v8jxj3d1dzdz08w.com" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "IDN domain from request server name is translated to ASCII."
+    (let [uri (client/req->domain {:scheme "https"
+                                   :server-name "名がドメイン.com"
+                                   :port 80})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "xn--v8jxj3d1dzdz08w.com" (.getHost uri)))
+      (is (= 80 (.getPort uri))))))

--- a/test/aleph/http/client_test.clj
+++ b/test/aleph/http/client_test.clj
@@ -11,6 +11,7 @@
   (testing "ASCII domain is extracted from request host as is."
     (let [uri (client/req->domain {:scheme "https"
                                    :host "domainname.com"
+                                   :server-name "someotherdomainname.com"
                                    :port 80})]
       (is (= "https" (.getScheme uri)))
       (is (= "domainname.com" (.getHost uri)))
@@ -22,22 +23,43 @@
       (is (= "https" (.getScheme uri)))
       (is (= "domainname.com" (.getHost uri)))
       (is (= 80 (.getPort uri)))))
-  (testing "IDN domain in URL is translated to ASCII."
+  (testing "IDN in URL is translated to ASCII."
     (let [uri (client/req->domain {:url "https://名がドメイン.com:80"})]
       (is (= "https" (.getScheme uri)))
       (is (= "xn--v8jxj3d1dzdz08w.com" (.getHost uri)))
       (is (= 80 (.getPort uri)))))
-  (testing "IDN domain from request host is translated to ASCII."
+  (testing "IDN in request host is translated to ASCII."
     (let [uri (client/req->domain {:scheme "https"
                                    :host "名がドメイン.com"
+                                   :server-name "domainname.com"
                                    :port 80})]
       (is (= "https" (.getScheme uri)))
       (is (= "xn--v8jxj3d1dzdz08w.com" (.getHost uri)))
       (is (= 80 (.getPort uri)))))
-  (testing "IDN domain from request server name is translated to ASCII."
+  (testing "IDN in request server name is translated to ASCII."
     (let [uri (client/req->domain {:scheme "https"
                                    :server-name "名がドメイン.com"
                                    :port 80})]
       (is (= "https" (.getScheme uri)))
       (is (= "xn--v8jxj3d1dzdz08w.com" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "IDN + Internationalized TLD in URL is translated to ASCII."
+    (let [uri (client/req->domain {:url "https://名がドメイン.укр:80"})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "xn--v8jxj3d1dzdz08w.xn--j1amh" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "IDN + Internationalized TLD in request host is translated to ASCII."
+    (let [uri (client/req->domain {:scheme "https"
+                                   :host "名がドメイン.укр"
+                                   :server-name "domainname.com"
+                                   :port 80})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "xn--v8jxj3d1dzdz08w.xn--j1amh" (.getHost uri)))
+      (is (= 80 (.getPort uri)))))
+  (testing "IDN + Internationalized TLD in request server name is translated to ASCII."
+    (let [uri (client/req->domain {:scheme "https"
+                                   :server-name "名がドメイン.укр"
+                                   :port 80})]
+      (is (= "https" (.getScheme uri)))
+      (is (= "xn--v8jxj3d1dzdz08w.xn--j1amh" (.getHost uri)))
       (is (= 80 (.getPort uri))))))


### PR DESCRIPTION
Currently it's not possible to make HTTP request to [IDN URLs](https://en.wikipedia.org/wiki/Internationalized_domain_name) using the Aleph because it relies on `java.net.URI` to [extract domain from the URL](https://github.com/ztellman/aleph/blob/9dcfc60321700ce271a41fc4765671f6f3bef5eb/src/aleph/http/client.clj#L58-L79) and `java.net.URI` doesn't really support IDNs: depending on constructor used it either silently ignores such domain names (`.getHost` returns `null`) or fails with exception (current Aleph behavior): 
```
user> (require '[aleph.http.client :as client])
nil
user> (aleph.http.client/req->domain {:url "https://名がドメイン.com"})
URISyntaxException Illegal character in hostname at index 8: https://名がドメイン.com  java.net.URI$Parser.fail (URI.java:2848)
user> *e
#error {
 :cause "Illegal character in hostname at index 8: https://名がドメイン.com"
 :via
 [{:type java.net.URISyntaxException
   :message "Illegal character in hostname at index 8: https://名がドメイン.com"
   :at [java.net.URI$Parser fail "URI.java" 2848]}]
 :trace
 [[java.net.URI$Parser fail "URI.java" 2848]
  [java.net.URI$Parser parseHostname "URI.java" 3387]
  [java.net.URI$Parser parseServer "URI.java" 3236]
  [java.net.URI$Parser parseAuthority "URI.java" 3155]
  [java.net.URI$Parser parseHierarchical "URI.java" 3097]
  [java.net.URI$Parser parse "URI.java" 3053]
  [java.net.URI <init> "URI.java" 673]
  [aleph.http.client$eval38639$req__GT_domain__38646 invoke "client.clj" 75]
  <REPL-related stacktrace...>
  ]}
```

I've added UTF to ASCII translation for hostname, but I'm not sure it's best possible solution, as with this approach there is one additional URL transformation for each request. What do you think about it?

On a side note, do you really need `java.net.URI` instance as a domain? If I don't miss anything it's used only as a [key for connection pool](https://github.com/ztellman/aleph/blob/9dcfc60321700ce271a41fc4765671f6f3bef5eb/src/aleph/http.clj#L213), wouldn't protocol+domain+port _string_ be enough for this purpose?