### PR TITLE
Automatically set Content-Type header for multipart requests

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -317,7 +317,10 @@
                   (HttpHeaders/setKeepAlive req' keep-alive?))
 
                 (let [body (if-let [parts (get req :multipart)]
-                             (multipart/encode-body parts)
+                             (let [boundary (multipart/boundary)
+                                   content-type (str "multipart/form-data; boundary=" boundary)]
+                               (HttpHeaders/setHeader req' "Content-Type" content-type)
+                               (multipart/encode-body boundary parts))
                              (get req :body))]
                   (netty/safe-execute ch
                                       (http/send-message ch true ssl? req' body))))

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -60,11 +60,11 @@
   (let [te (when transfer-encoding (cc/name transfer-encoding))
         names-encoding (or transfer-encoding :qp)
         pne (encode part-name names-encoding)
-        cd (str "content-disposition: form-data; name=\"" pne "\""
+        cd (str "Content-Disposition: form-data; name=\"" pne "\""
                 (when name (str "; filename=\"" (encode name names-encoding) "\""))
                 \newline)
-        ct (str "content-type: " mime-type \newline)
-        cte (if-not te "" (str "content-transfer-encoding: " te \newline \newline))
+        ct (str "Content-Type: " mime-type \newline)
+        cte (str (if-not te "" (str "Content-Transfer-Encoding: " te \newline)) \newline)
         lcd (.length cd)
         lct (.length ct)
         lcte (.length cte)
@@ -103,7 +103,6 @@
      (doseq [^ByteBuffer part ps]
        (.put buf (bs/to-byte-buffer "\n"))
        (.put buf part)
-       (.put buf (bs/to-byte-buffer "\n"))
        (.put buf (bs/to-byte-buffer "\n"))
        (.flip b)
        (.put buf b))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -37,13 +37,13 @@
     (is (.contains body-str "name=\"part6\""))
     (is (.contains body-str "content1"))
     (is (.contains body-str "content2"))
-    (is (.contains body-str "content-disposition: form-data;"))
+    (is (.contains body-str "Content-Disposition: form-data;"))
     ;; default mime-type
-    (is (.contains body-str "content-type: application/octet-stream;charset=UTF-8"))
+    (is (.contains body-str "Content-Type: application/octet-stream;charset=UTF-8"))
     ;; omitting charset
-    (is (.contains body-str "content-type: application/json\n"))
+    (is (.contains body-str "Content-Type: application/json\n"))
     ;; mime-type + charset
-    (is (.contains body-str "content-type: application/xml;charset=ISO-8859-1"))
+    (is (.contains body-str "Content-Type: application/xml;charset=ISO-8859-1"))
     ;; filename header
     (is (.contains body-str "filename=\"content5.pdf\""))))
 
@@ -74,6 +74,6 @@
     (is (.contains body-str "name=\"file.txt\""))
     (is (.contains body-str "filename=\"file.txt\""))
     (is (.contains body-str "filename=\"text-file-to-send.txt\""))
-    (is (.contains body-str "content-type: text/plain\n"))
-    (is (.contains body-str "content-type: text/plain;charset=UTF-8\n"))
-    (is (.contains body-str "content-type: application/png\n"))))
+    (is (.contains body-str "Content-Type: text/plain\n"))
+    (is (.contains body-str "Content-Type: text/plain;charset=UTF-8\n"))
+    (is (.contains body-str "Content-Type: application/png\n"))))


### PR DESCRIPTION
Update for https://github.com/ztellman/aleph/pull/312 covering https://github.com/ztellman/aleph/issues/159 following the discussion with @royalaid. 

The problem is that most tools rely on valid "Content-Type: multipart/form-data" request header. Using httpbin.org for testing:

```clojure
user=>(-> (http/post "http://httpbin.org/post"
                     {:multipart [{:content (java.io.File. "./test/file.txt")}]})
          deref
          :body
          bs/to-string
          json/parse-string
          clojure.pprint/pprint)
{"args" {},
 "data" "",
 "files" {"file.txt" "this is a file"},
 "form" {},
 "headers"
 {"Connection" "close",
  "Content-Length" "147",
  "Content-Type" "multipart/form-data; boundary=f219104837fee06",
  "Host" "httpbin.org"},
 "json" nil,
 "origin" "194.44.212.15",
 "url" "http://httpbin.org/post"}
```