### PR TITLE
Prevent the parsing of empty streams

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -64,9 +64,10 @@
   "Resolve and apply Transit's JSON/MessagePack decoding."
   [in type & [opts]]
   {:pre [transit-enabled?]}
-  (let [reader (ns-resolve 'cognitect.transit 'reader)
-        read (ns-resolve 'cognitect.transit 'read)]
-    (read (reader in type (transit-read-opts opts)))))
+  (when (pos? (.available in))
+    (let [reader (ns-resolve 'cognitect.transit 'reader)
+          read (ns-resolve 'cognitect.transit 'read)]
+      (read (reader in type (transit-read-opts opts))))))
 
 (defn ^:dynamic transit-encode
   "Resolve and apply Transit's JSON/MessagePack encoding."


### PR DESCRIPTION
When trying to parse an empty response as `transit+json` an internal EOFException is thrown, regardless of the `:throw-exceptions` flag. When the stream is empty, we shouldn't even attempt to parse it.