### PR TITLE
Advanced timeout exceptions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,7 @@
             [lein-jammin "0.1.1"]
             [lein-marginalia "0.9.0"]
             [ztellman/lein-cljfmt "0.1.10"]]
+  :java-source-paths ["src/aleph/utils"]
   :cljfmt {:indents {#".*" [[:inner 0]]}}
   :test-selectors {:default #(not
                                (some #{:benchmark :stress}

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -224,7 +224,7 @@
                ;; pool timeout triggered
                (d/catch' TimeoutException
                  (fn [^Throwable e]
-                   (d/error-deferred (PoolTimeoutException. (.getMessage e)))))
+                   (d/error-deferred (PoolTimeoutException. e))))
 
                (d/chain'
                  (fn [conn]
@@ -238,7 +238,7 @@
                      (d/catch' TimeoutException
                        (fn [^Throwable e]
                          (flow/dispose pool k conn)
-                         (d/error-deferred (ConnectionTimeoutException. (.getMessage e)))))
+                         (d/error-deferred (ConnectionTimeoutException. e))))
 
                      ;; connection failed, bail out
                      (d/catch'
@@ -260,8 +260,8 @@
                                (d/catch' TimeoutException
                                  (fn [^Throwable e]
                                    (flow/dispose pool k conn)
-                                   (d/error-deferred (RequestTimeoutException. (.getMessage e)))))
-
+                                   (d/error-deferred (RequestTimeoutException. e))))
+                               
                                ;; request failed, dispose of the connection
                                (d/catch'
                                  (fn [e]

--- a/src/aleph/utils/ConnectionTimeoutException.java
+++ b/src/aleph/utils/ConnectionTimeoutException.java
@@ -9,5 +9,15 @@ public class ConnectionTimeoutException extends TimeoutException {
     public ConnectionTimeoutException(String message) {
         super(message);
     }
+    
+    public ConnectionTimeoutException(Throwable cause) {
+        super(cause.getMessage());
+        initCause(cause);
+    }
 
+    public ConnectionTimeoutException(String message, Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+    
 }

--- a/src/aleph/utils/ConnectionTimeoutException.java
+++ b/src/aleph/utils/ConnectionTimeoutException.java
@@ -1,0 +1,13 @@
+package aleph.utils;
+
+import java.util.concurrent.TimeoutException;
+
+public class ConnectionTimeoutException extends TimeoutException {
+
+    public ConnectionTimeoutException() { }
+    
+    public ConnectionTimeoutException(String message) {
+        super(message);
+    }
+
+}

--- a/src/aleph/utils/PoolTimeoutException.java
+++ b/src/aleph/utils/PoolTimeoutException.java
@@ -1,0 +1,13 @@
+package aleph.utils;
+
+import java.util.concurrent.TimeoutException;
+
+public class PoolTimeoutException extends TimeoutException {
+
+    public PoolTimeoutException() { }
+    
+    public PoolTimeoutException(String message) {
+        super(message);
+    }
+
+}

--- a/src/aleph/utils/PoolTimeoutException.java
+++ b/src/aleph/utils/PoolTimeoutException.java
@@ -10,4 +10,14 @@ public class PoolTimeoutException extends TimeoutException {
         super(message);
     }
 
+    public PoolTimeoutException(Throwable cause) {
+        super(cause.getMessage());
+        initCause(cause);
+    }
+
+    public PoolTimeoutException(String message, Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+    
 }

--- a/src/aleph/utils/RequestTimeoutException.java
+++ b/src/aleph/utils/RequestTimeoutException.java
@@ -1,0 +1,13 @@
+package aleph.utils;
+
+import java.util.concurrent.TimeoutException;
+
+public class RequestTimeoutException extends TimeoutException {
+
+    public RequestTimeoutException() { }
+    
+    public RequestTimeoutException(String message) {
+        super(message);
+    }
+
+}

--- a/src/aleph/utils/RequestTimeoutException.java
+++ b/src/aleph/utils/RequestTimeoutException.java
@@ -10,4 +10,14 @@ public class RequestTimeoutException extends TimeoutException {
         super(message);
     }
 
+    public RequestTimeoutException(Throwable cause) {
+        super(cause.getMessage());
+        initCause(cause);
+    }
+    
+    public RequestTimeoutException(String message, Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+    
 }

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -17,7 +17,10 @@
      File
      ByteArrayInputStream]
     [java.util.concurrent
-     TimeoutException]))
+     TimeoutException]
+    [aleph.utils
+     ConnectionTimeoutException
+     RequestTimeoutException]))
 
 ;;;
 
@@ -281,11 +284,21 @@
   (with-handler basic-handler
     (is (thrown? TimeoutException
           @(http-get "http://192.0.2.0" ;; "TEST-NET" in RFC 5737
+             {:connection-timeout 2}))))
+
+  (with-handler basic-handler
+    (is (thrown? ConnectionTimeoutException
+          @(http-get "http://192.0.2.0" ;; "TEST-NET" in RFC 5737
              {:connection-timeout 2})))))
 
 (deftest test-request-timeout
   (with-handler basic-handler
     (is (thrown? TimeoutException
+          @(http-get (str "http://localhost:" port "/slow")
+             {:request-timeout 5}))))
+
+  (with-handler basic-handler
+    (is (thrown? RequestTimeoutException
           @(http-get (str "http://localhost:" port "/slow")
              {:request-timeout 5})))))
 


### PR DESCRIPTION
`aleph.http/request` function accepts for now 3 types of timeouts: `pool-timeout`, `connection-timeout` and `request-timeout`.  The problem is that further during the request processing it's impossible to distinguish what actually happened when `j.u.c.TimeoutException` occurs (all 3 cases are handled in the same manner). It probably doesn't harm a lot with basic scenarios, but implementing something like a proxy server you have to know if the request was actually sent to a downstream or not.

Subclasses are used not to break existing code. Test cases are updated.