### PR TITLE
http/request read-timeout to prevent connections leak

### DIFF
--- a/src/aleph/utils/ReadTimeoutException.java
+++ b/src/aleph/utils/ReadTimeoutException.java
@@ -1,0 +1,23 @@
+package aleph.utils;
+
+import java.util.concurrent.TimeoutException;
+
+public class ReadTimeoutException extends TimeoutException {
+
+    public ReadTimeoutException() { }
+    
+    public ReadTimeoutException(String message) {
+        super(message);
+    }
+
+    public ReadTimeoutException(Throwable cause) {
+        super(cause.getMessage());
+        initCause(cause);
+    }
+    
+    public ReadTimeoutException(String message, Throwable cause) {
+        super(message);
+        initCause(cause);
+    }
+    
+}


### PR DESCRIPTION
`http/request` now accepts optional `read-timeout` param to throw `ReadTimeoutException` when it takes too long for the response to be completed preventing potential connections leak.