### PR TITLE
Enhanced content-transfer-encoding handling for multipart requests

### DIFF
--- a/src/aleph/http/encoding.clj
+++ b/src/aleph/http/encoding.clj
@@ -39,7 +39,7 @@
         r (byte-array (.capacity ^ByteBuf encoded))
         _ (.getBytes ^ByteBuf encoded 0 r)]
     (.release ^ByteBuf cb)
-    (.release encoded)
+    (.release ^ByteBuf encoded)
     (bs/to-byte-buffer r)))
 
 (defn encode [val encoding]

--- a/src/aleph/http/encoding.clj
+++ b/src/aleph/http/encoding.clj
@@ -50,4 +50,5 @@
     ;; both "binary" and "none" effectively mean "do nothing"
     :binary val
     :none val
-    nil))
+    (throw (IllegalArgumentException.
+            (str "unsupported encodiing given:" (pr-str encoding))))))

--- a/src/aleph/http/encoding.clj
+++ b/src/aleph/http/encoding.clj
@@ -47,8 +47,7 @@
     :base64 (encode-base64 val)
     :quoted-printable (encode-qp val)
     :qp (encode-qp val)
-    ;; both "binary" and "none" effectively mean "do nothing"
+    ;; "binary" effectively means "do nothing"
     :binary val
-    :none val
     (throw (IllegalArgumentException.
             (str "unsupported encodiing given:" (pr-str encoding))))))

--- a/src/aleph/http/encoding.clj
+++ b/src/aleph/http/encoding.clj
@@ -47,4 +47,7 @@
     :base64 (encode-base64 val)
     :quoted-printable (encode-qp val)
     :qp (encode-qp val)
+    ;; both "binary" and "none" effectively mean "do nothing"
+    :binary val
+    :none val
     nil))

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -61,10 +61,9 @@
 ;; transfer-encoding=:none omits "Content-Transfer-Encoding" header.
 (defn part-headers [^String part-name ^String mime-type transfer-encoding name]
   (let [te (when transfer-encoding (cc/name transfer-encoding))
-        names-encoding (or transfer-encoding :qp)
-        pne (encode part-name names-encoding)
+        pne (encode part-name :qp)
         cd (str "Content-Disposition: form-data; name=\"" pne "\""
-                (when name (str "; filename=\"" (encode name names-encoding) "\""))
+                (when name (str "; filename=\"" (encode name :qp) "\""))
                 \newline)
         ct (str "Content-Type: " mime-type \newline)
         cte (str (if (or (nil? transfer-encoding) (= :none transfer-encoding))

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -56,6 +56,9 @@
 ;;
 ;; RFC 2388, section 4.4:
 ;; The original local file name may be supplied as well...
+;;
+;; Note, that you can use transfer-encoding=:none or :binary to leave data "as is".
+;; transfer-encoding=:none omits "Content-Transfer-Encoding" header.
 (defn part-headers [^String part-name ^String mime-type transfer-encoding name]
   (let [te (when transfer-encoding (cc/name transfer-encoding))
         names-encoding (or transfer-encoding :qp)
@@ -64,7 +67,10 @@
                 (when name (str "; filename=\"" (encode name names-encoding) "\""))
                 \newline)
         ct (str "Content-Type: " mime-type \newline)
-        cte (str (if-not te "" (str "Content-Transfer-Encoding: " te \newline)) \newline)
+        cte (str (if (or (nil? transfer-encoding) (= :none transfer-encoding))
+                   ""
+                   (str "Content-Transfer-Encoding: " te \newline))
+                 \newline)
         lcd (.length cd)
         lct (.length ct)
         lcte (.length cte)

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -61,25 +61,15 @@
 ;; transfer-encoding=:none omits "Content-Transfer-Encoding" header.
 (defn part-headers [^String part-name ^String mime-type transfer-encoding name]
   (let [te (when transfer-encoding (cc/name transfer-encoding))
-        pne (encode part-name :qp)
-        cd (str "Content-Disposition: form-data; name=\"" pne "\""
-                (when name (str "; filename=\"" (encode name :qp) "\""))
+        cd (str "Content-Disposition: form-data; name=\"" part-name "\""
+                (when name (str "; filename=\"" name "\""))
                 \newline)
         ct (str "Content-Type: " mime-type \newline)
         cte (str (if (or (nil? transfer-encoding) (= :none transfer-encoding))
                    ""
                    (str "Content-Transfer-Encoding: " te \newline))
-                 \newline)
-        lcd (.length cd)
-        lct (.length ct)
-        lcte (.length cte)
-        size (+ lcd lct lcte)
-        buf (ByteBuffer/allocate size)]
-    (doto buf
-      (.put (bs/to-byte-buffer cd))
-      (.put (bs/to-byte-buffer ct))
-      (.put (bs/to-byte-buffer cte))
-      (.flip))))
+                 \newline)]
+    (bs/to-byte-buffer (str cd ct cte))))
 
 (defn encode-part
   "Generates the byte representation of a part for the bytebuffer"

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -86,7 +86,7 @@
   "Generates the byte representation of a part for the bytebuffer"
   [{:keys [part-name content mime-type charset transfer-encoding name] :as part}]
   (let [headers (part-headers part-name mime-type transfer-encoding name)
-        body (bs/to-byte-buffer (encode content (or transfer-encoding :qp)))
+        body (bs/to-byte-buffer (encode content (or transfer-encoding :none)))
         header-len (.limit ^ByteBuffer headers)
         size (+ header-len (.limit ^ByteBuffer body))
         buf (ByteBuffer/allocate size)]

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -94,7 +94,9 @@
                               {:part-name "part4"
                                :charset "UTF-8"
                                :content file-to-send}
-                              {:content file-to-send}])
+                              {:content file-to-send}
+                              {:content file-to-send
+                               :transfer-encoding :base64}])
         body-str (bs/to-string body)]
     (is (.contains body-str "name=\"part1\""))
     (is (.contains body-str "name=\"part2\""))
@@ -105,4 +107,5 @@
     (is (.contains body-str "filename=\"text-file-to-send.txt\""))
     (is (.contains body-str "Content-Type: text/plain\n"))
     (is (.contains body-str "Content-Type: text/plain;charset=UTF-8\n"))
-    (is (.contains body-str "Content-Type: application/png\n"))))
+    (is (.contains body-str "Content-Type: application/png\n"))
+    (is (.contains body-str "Content-Transfer-Encoding: base64\n"))))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -62,19 +62,20 @@
     (is (.contains body-str "Y29udGVudDE="))))
 
 (deftest test-binary-content-transfer-encoding
-  (let [body (mp/encode-body [{:part-name "part1"
-                               :content "content1"
-                               :transfer-encoding :binary}
-                              {:part-name "part2"
-                               :content "content2"
-                               :transfer-encoding :none}])
-        body-str (bs/to-string body)]
-    (is (.contains body-str "content1"))
-    (is (.contains body-str "content2"))
-    (testing "specify 'binary' in headers"
-      (is (.contains body-str "Content-Transfer-Encoding: binary")))
-    (testing "omits content-transfer-encoding for :none"
-      (is (false? (.contains body-str "none"))))))
+  (testing "specify 'binary' in headers"
+    (let [body (mp/encode-body [{:part-name "part1"
+                                 :content "content1"
+                                 :transfer-encoding :binary}])
+          body-str (bs/to-string body)]
+      (is (.contains body-str "content1"))
+      (is (.contains body-str "Content-Transfer-Encoding: binary"))))
+  (testing "omits content-transfer-encoding for nil"
+    (let [body (mp/encode-body [{:part-name "part2"
+                                 :content "content2"
+                                 :transfer-encoding nil}])
+          body-str (bs/to-string body)]
+      (is (.contains body-str "content2"))
+      (is (false? (.contains body-str "Content-Transfer-Encoding"))))))
 
 (deftest reject-unknown-transfer-encoding
   (is (thrown? IllegalArgumentException

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -53,6 +53,14 @@
         body-str (bs/to-string body)]
     (is (.endsWith body-str (str b "--")))))
 
+(deftest test-base64-encoding
+  (let [body (mp/encode-body [{:part-name "part1"
+                               :content "content1"
+                               :transfer-encoding :base64}])
+        body-str (bs/to-string body)]
+    (is (.contains body-str "base64"))
+    (is (.contains body-str "Y29udGVudDE="))))
+
 (deftest test-content-as-file
   (let [body (mp/encode-body [{:part-name "part1"
                                :content file-to-send}

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -76,6 +76,12 @@
     (testing "omits content-transfer-encoding for :none"
       (is (false? (.contains body-str "none"))))))
 
+(deftest reject-unknown-transfer-encoding
+  (is (thrown? IllegalArgumentException
+               (mp/encode-body [{:part-name "part1"
+                                 :content "content1"
+                                 :transfer-encoding :uknown-transfer-encoding}]))))
+
 (deftest test-content-as-file
   (let [body (mp/encode-body [{:part-name "part1"
                                :content file-to-send}

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -53,13 +53,28 @@
         body-str (bs/to-string body)]
     (is (.endsWith body-str (str b "--")))))
 
-(deftest test-base64-encoding
+(deftest test-base64-content-transfer-encoding
   (let [body (mp/encode-body [{:part-name "part1"
                                :content "content1"
                                :transfer-encoding :base64}])
         body-str (bs/to-string body)]
     (is (.contains body-str "base64"))
     (is (.contains body-str "Y29udGVudDE="))))
+
+(deftest test-binary-content-transfer-encoding
+  (let [body (mp/encode-body [{:part-name "part1"
+                               :content "content1"
+                               :transfer-encoding :binary}
+                              {:part-name "part2"
+                               :content "content2"
+                               :transfer-encoding :none}])
+        body-str (bs/to-string body)]
+    (is (.contains body-str "content1"))
+    (is (.contains body-str "content2"))
+    (testing "specify 'binary' in headers"
+      (is (.contains body-str "Content-Transfer-Encoding: binary")))
+    (testing "omits content-transfer-encoding for :none"
+      (is (false? (.contains body-str "none"))))))
 
 (deftest test-content-as-file
   (let [body (mp/encode-body [{:part-name "part1"


### PR DESCRIPTION
There are quite a few changes. What was done here:

1. Fixed `base64` encoding. Setting `:transfer-encoding` to `base64` right now throws an exception. And as far as I see it never worked properly. Conversion between Netty and NIO ByteBuf is not optimal in terms of performance in new implementation, but I did it following the same pattern as it's done for user/pass encoding (to prevent problems with different JDK versions).

2. `:binary` encoding could be specified in case we want to send data to the server "as is" explicitly marking “Content-Transfer-Encoding: binary” (allowed by the RFC).

There are also a few changes that might break someone's code. Which is highly unlikely as this functionality was essentially broken, but I’m open to a conversation here.

1. `aleph.http.encoding/encode` function throws an `IllegalArgumentException` when unsupported encoding is given (was: return `nil`) Silent fallback to `nil` as an output value might lead to very clumsy issues.

2. We do not do any encoding if `transfer-encoding` is not specified explicitly (was: default to `quoted-printable`) to match default behavior of most clients, like CURL. `quoted-printable` is rarely used nowadays and using it leads to almost doubling the size of the request containing binary data, such as pictures or video.
