### PR TITLE
HTTP Client middleware to deal with cookies, including cookies storage support

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -336,7 +336,7 @@
    | `body` | an optional body, which should be coercable to a byte representation via [byte-streams](https://github.com/ztellman/byte-streams)
    | `multipart` | a vector of bodies
    | `cookie-store` | an optional instance of cookie store to maintain cookies across requests
-   | `cookie-spec` | an optional instance of a cookie management specification to enforce rules of parrsing, formatting and choosing cookies to be send with the request, defaults to the `middleware/default-cookies-spec`")
+   | `cookie-spec` | an optional instance of a cookie management specification to enforce rules of parsing, formatting and choosing cookies to be send with the request, defaults to the `middleware/default-cookies-spec`")
        :arglists arglists)))
 
 (def-http-method get)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -6,7 +6,6 @@
     [manifold.executor :as executor]
     [aleph.flow :as flow]
     [aleph.http
-     [core :as http]
      [server :as server]
      [client :as client]
      [client-middleware :as middleware]])
@@ -318,8 +317,10 @@
 (def ^:private arglists
   '[[url]
     [url
-     {:keys [pool middleware headers body multipart cookie-store]
-      :or {pool default-connection-pool middleware identity}
+     {:keys [pool middleware headers body multipart cookie-store cookie-spec]
+      :or {pool default-connection-pool
+           middleware identity
+           cookie-spec middleware/default-cookie-spec}
       :as options}]])
 
 (defmacro ^:private def-http-method [method]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -336,7 +336,7 @@
    | `body` | an optional body, which should be coercable to a byte representation via [byte-streams](https://github.com/ztellman/byte-streams)
    | `multipart` | a vector of bodies
    | `cookie-store` | an optional instance of cookie store to maintain cookies across requests
-   | `cookie-spec` | an optional instance of a cookie management specification to enforce rules of parrsing, formatting and choosing cookies to be send with the request, defaults to the `middleware/default-cookies-spec` providing RFC6265 compliant behavior with no validation for cookie names and values")
+   | `cookie-spec` | an optional instance of a cookie management specification to enforce rules of parrsing, formatting and choosing cookies to be send with the request, defaults to the `middleware/default-cookies-spec`")
        :arglists arglists)))
 
 (def-http-method get)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -206,15 +206,12 @@
              connection-timeout
              request-timeout
              read-timeout
-             follow-redirects?
-             cookie-store
-             cookie-spec]
+             follow-redirects?]
       :or {pool default-connection-pool
            response-executor default-response-executor
            middleware identity
            connection-timeout 6e4 ;; 60 seconds
-           follow-redirects? true
-           cookie-spec middleware/default-cookie-spec}
+           follow-redirects? true}
       :as req}]
 
     (executor/with-executor response-executor
@@ -258,9 +255,8 @@
                        (fn [conn']
 
                          (when-not (nil? conn')
-                           (let [end (System/currentTimeMillis)
-                                 req' (middleware/add-cookie-header cookie-store cookie-spec req)]
-                             (-> (conn' req')
+                           (let [end (System/currentTimeMillis)]
+                             (-> (conn' req)
                                (maybe-timeout! request-timeout)
 
                                ;; request timeout triggered, dispose of the connection
@@ -301,7 +297,7 @@
 
                        (fn [rsp]
                          (->> rsp
-                              (middleware/handle-cookies cookie-store cookie-spec req)
+                              (middleware/handle-cookies req)
                               (middleware/handle-redirects request req)))))))))))
         req))))
 

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -221,7 +221,7 @@
     (executor/with-executor response-executor
       ((middleware
          (fn [req]
-           (let [k (http/req->domain req)
+           (let [k (client/req->domain req)
                  start (System/currentTimeMillis)]
 
              ;; acquire a connection
@@ -260,9 +260,7 @@
 
                          (when-not (nil? conn')
                            (let [end (System/currentTimeMillis)
-                                 ;; try to avoid parsing URI twice
-                                 req' (->> (assoc req :aleph/uri k)
-                                           (middleware/add-cookie-header cookie-store cookie-spec))]
+                                 req' (middleware/add-cookie-header cookie-store cookie-spec req)]
                              (-> (conn' req')
                                (maybe-timeout! request-timeout)
 

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -260,10 +260,9 @@
 
                          (when-not (nil? conn')
                            (let [end (System/currentTimeMillis)
-                                 req' (-> req
-                                          ;; try to avoid parsing URI twice
-                                          (assoc :aleph/uri k)
-                                          (middleware/add-cookie-header cookie-store cookie-spec))]
+                                 ;; try to avoid parsing URI twice
+                                 req' (->> (assoc req :aleph/uri k)
+                                           (middleware/add-cookie-header cookie-store cookie-spec))]
                              (-> (conn' req')
                                (maybe-timeout! request-timeout)
 

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -313,10 +313,9 @@
 (def ^:private arglists
   '[[url]
     [url
-     {:keys [pool middleware headers body multipart cookie-store cookie-spec]
+     {:keys [pool middleware headers body multipart]
       :or {pool default-connection-pool
-           middleware identity
-           cookie-spec middleware/default-cookie-spec}
+           middleware identity}
       :as options}]])
 
 (defmacro ^:private def-http-method [method]
@@ -331,9 +330,7 @@
    | `middleware` | any additional middleware that should be used for handling requests and responses
    | `headers` | the HTTP headers for the request
    | `body` | an optional body, which should be coercable to a byte representation via [byte-streams](https://github.com/ztellman/byte-streams)
-   | `multipart` | a vector of bodies
-   | `cookie-store` | an optional instance of cookie store to maintain cookies across requests
-   | `cookie-spec` | an optional instance of a cookie management specification to enforce rules of parsing, formatting and choosing cookies to be send with the request, defaults to the `middleware/default-cookies-spec`")
+   | `multipart` | a vector of bodies")
        :arglists arglists)))
 
 (def-http-method get)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -208,12 +208,14 @@
              request-timeout
              read-timeout
              follow-redirects?
-             cookie-store]
+             cookie-store
+             cookie-spec]
       :or {pool default-connection-pool
            response-executor default-response-executor
            middleware identity
            connection-timeout 6e4 ;; 60 seconds
-           follow-redirects? true}
+           follow-redirects? true
+           cookie-spec middleware/default-cookie-spec}
       :as req}]
 
     (executor/with-executor response-executor
@@ -261,7 +263,7 @@
                                  req' (-> req
                                           ;; try to avoid parsing URI twice
                                           (assoc :aleph/uri k)
-                                          (middleware/add-cookie-header cookie-store))]
+                                          (middleware/add-cookie-header cookie-store cookie-spec))]
                              (-> (conn' req')
                                (maybe-timeout! request-timeout)
 
@@ -303,7 +305,7 @@
 
                        (fn [rsp]
                          (->> rsp
-                              (middleware/handle-cookies cookie-store req)
+                              (middleware/handle-cookies cookie-store cookie-spec req)
                               (middleware/handle-redirects request req)))))))))))
         req))))
 
@@ -336,7 +338,8 @@
    | `headers` | the HTTP headers for the request
    | `body` | an optional body, which should be coercable to a byte representation via [byte-streams](https://github.com/ztellman/byte-streams)
    | `multipart` | a vector of bodies
-   | `cookie-store` | an optional instance of cookie store to maintain cookies across requests")
+   | `cookie-store` | an optional instance of cookie store to maintain cookies across requests
+   | `cookie-spec` | an optional instance of a cookie management specification to enforce rules of parrsing, formatting and choosing cookies to be send with the request, defaults to the `middleware/default-cookies-spec` providing RFC6265 compliant behavior with no validation for cookie names and values")
        :arglists arglists)))
 
 (def-http-method get)

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -13,9 +13,7 @@
      IOException]
     [java.net
      URI
-     URL
-     InetSocketAddress
-     IDN]
+     InetSocketAddress]
     [io.netty.buffer
      ByteBuf
      Unpooled]
@@ -56,28 +54,9 @@
 
 ;;;
 
-(let [no-url (fn [req]
-               (URI.
-                 (name (or (:scheme req) :http))
-                 nil
-                 (some-> (or (:host req) (:server-name req)) IDN/toASCII)
-                 (or (:port req) (:server-port req) -1)
-                 nil
-                 nil
-                 nil))]
-
-  (defn ^java.net.URI req->domain [req]
-    (if-let [url (:url req)]
-      (let [^URL uri (URL. url)]
-        (URI.
-          (.getProtocol uri)
-          nil
-          (IDN/toASCII (.getHost uri))
-          (.getPort uri)
-          nil
-          nil
-          nil))
-      (no-url req))))
+;; moved to http.core to be reused in http.clint-middlware
+(defn ^java.net.URI req->domain [req]
+  (http/req->domain req))
 
 (defn raw-client-handler
   [response-stream buffer-capacity]

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -13,7 +13,9 @@
      IOException]
     [java.net
      URI
-     InetSocketAddress]
+     InetSocketAddress
+     IDN
+     URL]
     [io.netty.buffer
      ByteBuf
      Unpooled]

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -54,9 +54,28 @@
 
 ;;;
 
-;; moved to http.core to be reused in http.clint-middlware
-(defn ^java.net.URI req->domain [req]
-  (http/req->domain req))
+(let [no-url (fn [req]
+               (URI.
+                 (name (or (:scheme req) :http))
+                 nil
+                 (some-> (or (:host req) (:server-name req)) IDN/toASCII)
+                 (or (:port req) (:server-port req) -1)
+                 nil
+                 nil
+                 nil))]
+
+  (defn ^java.net.URI req->domain [req]
+    (if-let [url (:url req)]
+      (let [^URL uri (URL. url)]
+        (URI.
+          (.getProtocol uri)
+          nil
+          (IDN/toASCII (.getHost uri))
+          (.getPort uri)
+          nil
+          nil
+          nil))
+      (no-url req))))
 
 (defn raw-client-handler
   [response-stream buffer-capacity]

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -22,8 +22,7 @@
    [io.netty.handler.codec.http.cookie
     ClientCookieDecoder
     ClientCookieEncoder
-    DefaultCookie
-    Cookie]
+    DefaultCookie]
    [java.io InputStream ByteArrayOutputStream]
    [java.nio.charset StandardCharsets]
    [java.net IDN URL URLEncoder UnknownHostException]))
@@ -764,18 +763,24 @@
     (.setPath path)
     (.setHttpOnly (or http-only? false))
     (.setSecure (or secure? false))
-    (.setMaxAge (or max-age Cookie/UNDEFINED_MAX_AGE))))
+    (.setMaxAge (or max-age io.netty.handler.codec.http.cookie.Cookie/UNDEFINED_MAX_AGE))))
 
 ;; xxx: replace with def-map-type
+
+(p/def-derived-map Cookie
+  [^DefaultCookie cookie]
+  :domain (.domain cookie)
+  :http-only? (.isHttpOnly cookie)
+  :secure? (.isSecure cookie)
+  :max-age (let [max-age (.maxAge cookie)]
+             (when-not (= max-age io.netty.handler.codec.http.cookie.Cookie/UNDEFINED_MAX_AGE)
+               max-age))
+  :name (.name cookie)
+  :path (.path cookie)
+  :value (.value cookie))
+
 (defn netty-cookie->cookie [^DefaultCookie cookie]
-  {:domain (.domain cookie)
-   :http-only? (.isHttpOnly cookie)
-   :secure? (.isSecure cookie)
-   :max-age (let [max-age (.maxAge cookie)]
-              (if (= max-age Cookie/UNDEFINED_MAX_AGE) nil max-age))
-   :name (.name cookie)
-   :path (.path cookie)
-   :value (.value cookie)})
+  (->Cookie cookie))
 
 (defn decode-set-cookie-header
   ([header]

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -752,10 +752,10 @@
 (defn cookie->netty-cookie [{:keys [domain http-only? secure? max-age name path value]}]
   (doto (DefaultCookie. name value)
     (.setDomain domain)
-    (.setHttpOnly http-only?)
-    (.setSecure secure?)
-    (.setMaxAge (or max-age Cookie/UNDEFINED_MAX_AGE))
-    (.setPath path)))
+    (.setPath path)
+    (.setHttpOnly (or http-only? false))
+    (.setSecure (or secure? false))
+    (.setMaxAge (or max-age Cookie/UNDEFINED_MAX_AGE))))
 
 ;; xxx: replace with def-map-type
 (defn netty-cookie->cookie [^DefaultCookie cookie]

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -52,6 +52,7 @@
     (clojure.core/get opts type)
     :else
     (let [class (Class/forName class-name)]
+      (println "Deprecated use of :transit-opts found.")
       (update-in opts [:handlers]
         (fn [handlers]
           (->> handlers

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -760,13 +760,13 @@
    Each cookie should be represented as a map:
 
    |:---|:---
-   | name | name of this cookie
-   | value | value of this cookie
-   | domain | specifies allowed hosts to receive the cookie (including subdomains)
-   | path | indicates a URL path that must exist in the requested URL in order to send the 'Cookie' header
-   | http-only? | when set to `true`, cookie can only be accessed by HTTP. Optional, defaults to `false` 
-   | secure? | when set to `true`, cookie can only be transmitted over an encrypted connection. Optional, defaults to `false`
-   | max-age | set maximum age of this cookie in seconds. Options, defaults to UNDEFINED_MAX_AGE."
+   | `name` | name of this cookie
+   | `value` | value of this cookie
+   | `domain` | specifies allowed hosts to receive the cookie (including subdomains)
+   | `path` | indicates a URL path that must exist in the requested URL in order to send the 'Cookie' header
+   | `http-only?` | when set to `true`, cookie can only be accessed by HTTP. Optional, defaults to `false`
+   | `secure?` | when set to `true`, cookie can only be transmitted over an encrypted connection. Optional, defaults to `false`
+   | `max-age` | set maximum age of this cookie in seconds. Options, defaults to `io.netty.handler.codec.http.cookie.Cookie/UNDEFINED_MAX_AGE`."
   [{:keys [cookie-store cookie-spec cookies]
     :or {cookie-spec default-cookie-spec
          cookies '()}

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -408,26 +408,3 @@
         (handle-cleanup ch f))
 
       f)))
-
-(let [no-url (fn [req]
-               (URI.
-                 (name (or (:scheme req) :http))
-                 nil
-                 (some-> (or (:host req) (:server-name req)) IDN/toASCII)
-                 (or (:port req) (:server-port req) -1)
-                 nil
-                 nil
-                 nil))]
-
-  (defn ^java.net.URI req->domain [req]
-    (if-let [url (:url req)]
-      (let [^URL uri (URL. url)]
-        (URI.
-          (.getProtocol uri)
-          nil
-          (IDN/toASCII (.getHost uri))
-          (.getPort uri)
-          nil
-          nil
-          nil))
-      (no-url req))))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -35,6 +35,9 @@
      RandomAccessFile
      Closeable]
     [java.net
+     URI
+     URL
+     IDN
      InetSocketAddress]
     [java.util
      Map$Entry]
@@ -405,3 +408,26 @@
         (handle-cleanup ch f))
 
       f)))
+
+(let [no-url (fn [req]
+               (URI.
+                 (name (or (:scheme req) :http))
+                 nil
+                 (some-> (or (:host req) (:server-name req)) IDN/toASCII)
+                 (or (:port req) (:server-port req) -1)
+                 nil
+                 nil
+                 nil))]
+
+  (defn ^java.net.URI req->domain [req]
+    (if-let [url (:url req)]
+      (let [^URL uri (URL. url)]
+        (URI.
+          (.getProtocol uri)
+          nil
+          (IDN/toASCII (.getHost uri))
+          (.getPort uri)
+          nil
+          nil
+          nil))
+      (no-url req))))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -35,9 +35,6 @@
      RandomAccessFile
      Closeable]
     [java.net
-     URI
-     URL
-     IDN
      InetSocketAddress]
     [java.util
      Map$Entry]

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -90,4 +90,15 @@
                                          :url "https://domain.com/"
                                          :headers {"cookie" "no_override"}})
                (get-in  [:headers "cookie"])))
-        "no attempts to override when header is already set")))
+        "no attempts to override when header is already set")
+    (is (= "id=44" (-> (middleware/wrap-cookies {:url "https://domain.com/"
+                                                 :cookies [{:name "id"
+                                                            :value "44"
+                                                            :domain "domain.com"}]})
+                       (get-in [:headers "cookie"])))
+        "accept cookies from req directly")
+    (is (= "name=John" (-> (middleware/wrap-cookies {:url "https://domain.com/"
+                                                     :cookies [{:name "name" :value "John"}]
+                                                     :cookie-store cs})
+                           (get-in [:headers "cookie"])))
+        "explicitly set cookies override cookie-store even when specified")))

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -85,7 +85,9 @@
                   (get-in [:headers "cookie"])))
         "should not set expired")
     (is (= "no_override"
-           (-> (middleware/add-cookie-header cs spec {:url "https://domain.com/"
-                                                      :headers {"cookie" "no_override"}})
+           (-> (middleware/wrap-cookies {:cookie-store cs
+                                         :cookie-spec spec
+                                         :url "https://domain.com/"
+                                         :headers {"cookie" "no_override"}})
                (get-in  [:headers "cookie"])))
         "no attempts to override when header is already set")))


### PR DESCRIPTION
Effectively covers [this issue](https://github.com/ztellman/aleph/issues/188).

Implementation provides:
* mutable in-memory cookie store to maintain cookies across requests
* default cookies parsing, formatting, and matching specification (RFC6265 compliant with slightly extended domain matching procedure to cover older servers/clients)
* protocols to extend/change this behavior when necessary (i.e. when persistent storage is required or cookies matching should be changed due to proxying rules)

Heavily influenced by `CookieStore` and `CookieSpec` implementations from Apache HttpClient (used internally by `clj_http`) and Python's [cookielib](https://docs.python.org/2/library/cookielib.html).

How to use:

```clojure
(http/get "https://google.com" {:cookies [{:name "googleID" :value "42"}]})
```

Using cookie store:

```clojure
(def cookies (http.client-middleware/in-memory-cookie-store))
@(http/post "https://mysite.com/login" {:form-params {:user "me" :password "123456"}
                                        :cookie-store cookies})
;; the request below will be sent with cookies set previously
@(http/get "https://mysite.com/protected" {:cookie-store cookies})
```