### PR TITLE
Basic auth: Don't add line breaks to encoded string

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -437,7 +437,7 @@
                      basic-auth
                      (str (first basic-auth) ":" (second basic-auth)))
         input-bytebuf (Unpooled/wrappedBuffer (.getBytes ^String basic-auth "UTF-8"))
-        base64-bytebuf (Base64/encode input-bytebuf)
+        base64-bytebuf (Base64/encode input-bytebuf false)
         base64-string (.toString ^ByteBuf base64-bytebuf StandardCharsets/UTF_8)]
     (.release ^ByteBuf input-bytebuf)
     (.release ^ByteBuf base64-bytebuf)


### PR DESCRIPTION
```io.netty.handler.codec.base64.Base64.encode()``` adds line breaks per default which causes basic auth for base64 encoded strings with more than 76 characters to break.

```clj
(require '[aleph.http :as http])
@(http/get "http://google.com" {:basic-auth (apply str (take 58 (repeat "a")))})
IllegalArgumentException only ' ' and '\t' are allowed after '\n': Basic YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh
YQ==  io.netty.handler.codec.http.DefaultHttpHeaders$HeaderValueConverterAndValidator.validateValueChar (DefaultHttpHeaders.java:462)
```