### PR TITLE
Upgrade :query-params and :form-params handling

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -190,7 +190,10 @@
   [{:keys [content-type] :as req}]
   (let [default-content-type? (or (nil? content-type)
                                   (= content-type :x-www-form-urlencoded))
-        nested-keys (cond-> [:query-params]
+        nested-keys (cond-> []
+                      (not (opt req :ignore-nested-query-string))
+                      (conj :query-params)
+                      
                       default-content-type?
                       (conj :form-params))]
     (reduce nest-params req nested-keys)))

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -429,9 +429,11 @@
     :or {content-type :x-www-form-urlencoded
          multi-param-style :default}
     :as req}]
-  (if query-params
+  (if (nil? query-params)
+    req
     (-> req
         (dissoc :query-params)
+        (dissoc :multi-param-style)
         (update-in [:query-string]
                    (fn [old-query-string new-query-string]
                      (if-not (empty? old-query-string)
@@ -440,8 +442,7 @@
                    (generate-query-string
                     query-params
                     (content-type-value content-type)
-                    multi-param-style)))
-    req))
+                    multi-param-style)))))
 
 (defn basic-auth-value
   "Accept a String of the form \"username:password\" or a vector of 2 strings [username password], return a String with the basic auth header (see https://tools.ietf.org/html/rfc2617#page-5)"

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -190,11 +190,14 @@
   [{:keys [content-type] :as req}]
   (let [default-content-type? (or (nil? content-type)
                                   (= content-type :x-www-form-urlencoded))
+        flatten-form? (opt req :flatten-nested-form-params)
         nested-keys (cond-> []
                       (not (opt req :ignore-nested-query-string))
                       (conj :query-params)
                       
-                      default-content-type?
+                      (and default-content-type?
+                           (or (nil? flatten-form?)
+                               (true? flatten-form?)))
                       (conj :form-params))]
     (reduce nest-params req nested-keys)))
 

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -188,13 +188,12 @@
 (defn wrap-nested-params
   "Middleware wrapping nested parameters for query strings."
   [{:keys [content-type] :as req}]
-  (if (or (nil? content-type)
-          (= content-type :x-www-form-urlencoded))
-    (reduce
-     nest-params
-     req
-     [:query-params :form-params])
-    req))
+  (let [default-content-type? (or (nil? content-type)
+                                  (= content-type :x-www-form-urlencoded))
+        nested-keys (cond-> [:query-params]
+                      default-content-type?
+                      (conj :form-params))]
+    (reduce nest-params req nested-keys)))
 
 ;; Statuses for which clj-http will not throw an exception
 (def unexceptional-status?

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -64,6 +64,12 @@
                                                   :ignore-nested-query-string true})))
   (is (= "foo[bar]=baz" (req->body-decoded {:method :post
                                             :form-params {:foo {:bar "baz"}}})))
+  (is (= "foo[bar]=baz" (req->body-decoded {:method :post
+                                            :flatten-nested-form-params true
+                                            :form-params {:foo {:bar "baz"}}})))
+  (is (= "foo={:bar \"baz\"}" (req->body-decoded {:method :post
+                                                  :flatten-nested-form-params false
+                                                  :form-params {:foo {:bar "baz"}}})))
   (is (= "{\"foo\":{\"bar\":\"baz\"}}"
          (req->body-raw {:method :post
                          :content-type :json

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -58,6 +58,10 @@
   (is (= "foo[bar]=baz" (req->query-string {:query-params {:foo {:bar "baz"}}})))
   (is (= "foo[bar]=baz" (req->query-string {:query-params {:foo {:bar "baz"}}
                                             :content-type :json})))
+  (is (= "foo[bar]=baz" (req->query-string {:query-params {:foo {:bar "baz"}}
+                                            :ignore-nested-query-string false})))
+  (is (= "foo={:bar \"baz\"}" (req->query-string {:query-params {:foo {:bar "baz"}}
+                                                  :ignore-nested-query-string true})))
   (is (= "foo[bar]=baz" (req->body-decoded {:method :post
                                             :form-params {:foo {:bar "baz"}}})))
   (is (= "{\"foo\":{\"bar\":\"baz\"}}"

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -35,3 +35,13 @@
   (let [req {:query-params {:foo {:bar "baz"}}}
         {:keys [query-string]} (reduce #(%2 %1) req middleware/default-middleware)]
     (is (= "foo[bar]=baz" (URLDecoder/decode query-string)))))
+
+(deftest test-query-string-multi-param
+  (is (= "name=John" (middleware/generate-query-string {:name "John"})))
+  (is (= "name=John&name=Mark" (middleware/generate-query-string {:name ["John" "Mark"]})))
+  (is (= "name=John&name=Mark"
+         (middleware/generate-query-string {:name ["John" "Mark"]} nil :default)))
+  (is (= "name[]=John&name[]=Mark"
+         (middleware/generate-query-string {:name ["John" "Mark"]} nil :array)))
+  (is (= "name[0]=John&name[1]=Mark"
+         (middleware/generate-query-string {:name ["John" "Mark"]} nil :indexed))))

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -43,10 +43,15 @@
                                          :form-params {:foo :bar}})
         (middleware/coerce-form-params {:form-params {:foo :bar}}))))
 
+(defn req->query-string [req]
+  (-> (reduce #(%2 %1) req middleware/default-middleware)
+      :query-string
+      URLDecoder/decode))
+
 (deftest test-nested-query-params
-  (let [req {:query-params {:foo {:bar "baz"}}}
-        {:keys [query-string]} (reduce #(%2 %1) req middleware/default-middleware)]
-    (is (= "foo[bar]=baz" (URLDecoder/decode query-string)))))
+  (is (= "foo[bar]=baz" (req->query-string {:query-params {:foo {:bar "baz"}}})))
+  (is (= "foo[bar]=baz" (req->query-string {:query-params {:foo {:bar "baz"}}
+                                            :content-type :json}))))
 
 (deftest test-query-string-multi-param
   (is (= "name=John" (middleware/generate-query-string {:name "John"})))

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -21,12 +21,24 @@
 (deftest test-coerce-form-params
   (is (= "{\"foo\":\"bar\"}" (middleware/coerce-form-params {:content-type :json
                                                              :form-params {:foo :bar}})))
-  (is (= "[\"^ \",\"~:foo\",\"~:bar\"]" (slurp (middleware/coerce-form-params {:content-type :transit+json
-                                                                               :form-params {:foo :bar}}))))
+  (is (= "[\"^ \",\"~:foo\",\"~:bar\"]"
+         (slurp (middleware/coerce-form-params {:content-type :transit+json
+                                                :form-params {:foo :bar}}))))
   (is (= "{:foo :bar}" (middleware/coerce-form-params {:content-type :edn
                                                        :form-params {:foo :bar}})))
   (is (= "foo=%3Abar" (middleware/coerce-form-params {:content-type :default
                                                       :form-params {:foo :bar}})))
+  (is (= "foo=%3Abar&foo=%3Abaz"
+         (middleware/coerce-form-params {:content-type :default
+                                         :form-params {:foo [:bar :baz]}})))
+  (is (= "foo[]=%3Abar&foo[]=%3Abaz"
+         (middleware/coerce-form-params {:content-type :default
+                                         :multi-param-style :array
+                                         :form-params {:foo [:bar :baz]}})))
+  (is (= "foo[0]=%3Abar&foo[1]=%3Abaz"
+         (middleware/coerce-form-params {:content-type :default
+                                         :multi-param-style :indexed
+                                         :form-params {:foo [:bar :baz]}})))
   (is (= (middleware/coerce-form-params {:content-type :default
                                          :form-params {:foo :bar}})
         (middleware/coerce-form-params {:form-params {:foo :bar}}))))

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -70,6 +70,15 @@
   (is (= "foo={:bar \"baz\"}" (req->body-decoded {:method :post
                                                   :flatten-nested-form-params false
                                                   :form-params {:foo {:bar "baz"}}})))
+  (is (= "foo={:bar \"baz\"}" (req->body-decoded {:method :post
+                                                  :flatten-nested-keys []
+                                                  :form-params {:foo {:bar "baz"}}})))
+  (is (= "foo={:bar \"baz\"}" (req->body-decoded {:method :post
+                                                  :flatten-nested-keys [:query-params]
+                                                  :form-params {:foo {:bar "baz"}}})))
+  (is (= "foo[bar]=baz" (req->body-decoded {:method :post
+                                            :flatten-nested-keys [:form-params]
+                                            :form-params {:foo {:bar "baz"}}})))
   (is (= "{\"foo\":{\"bar\":\"baz\"}}"
          (req->body-raw {:method :post
                          :content-type :json

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -48,10 +48,22 @@
       :query-string
       URLDecoder/decode))
 
-(deftest test-nested-query-params
+(defn req->body-raw [req]
+  (:body (reduce #(%2 %1) req middleware/default-middleware)))
+
+(defn req->body-decoded [req]
+  (URLDecoder/decode (req->body-raw req)))
+
+(deftest test-nested-params
   (is (= "foo[bar]=baz" (req->query-string {:query-params {:foo {:bar "baz"}}})))
   (is (= "foo[bar]=baz" (req->query-string {:query-params {:foo {:bar "baz"}}
-                                            :content-type :json}))))
+                                            :content-type :json})))
+  (is (= "foo[bar]=baz" (req->body-decoded {:method :post
+                                            :form-params {:foo {:bar "baz"}}})))
+  (is (= "{\"foo\":{\"bar\":\"baz\"}}"
+         (req->body-raw {:method :post
+                         :content-type :json
+                         :form-params {:foo {:bar "baz"}}}))))
 
 (deftest test-query-string-multi-param
   (is (= "name=John" (middleware/generate-query-string {:name "John"})))


### PR DESCRIPTION
Actually, 2 different changes are made.

1. This [issue](https://github.com/ztellman/aleph/issues/294) is fixed (more [here](https://github.com/ztellman/aleph/issues/284) and [here](https://github.com/ztellman/aleph/pull/286)). A full description of the [problem](https://github.com/dakrone/clj-http/issues/427). Current implementation covers appropriate handling for nested query and form params "by default" and provides support for new options: `:ignore-nested-query-string`, `:flatten-nested-form-params`, `:flatten-nested-keys` for even more fine-grained control.

2. `:multi-param-style` support is added.

Provides the same behavior as described [here](https://github.com/dakrone/clj-http#query-string-parameters). Covers:

* default style (repeating parameter)
* repeating param with array suffix 
* indexed array style (rails-like).

Examples:

```clojure
user=> (middleware/wrap-query-params {:query-params {:name ["Jonh" "Mark"]}})
{:query-string "name=Jonh&name=Mark"}
user=> (middleware/wrap-query-params {:query-params {:name ["Jonh" "Mark"]} :multi-param-style :array})
{:query-string "name[]=Jonh&name[]=Mark"}
user=> (middleware/wrap-query-params {:query-params {:name ["Jonh" "Mark"]} :multi-param-style :indexed})
{:query-string "name[0]=Jonh&name[1]=Mark"}
```

Works for nested query params as well.