### PR TITLE
A few clj-http parity fixes

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -17,7 +17,7 @@
    [io.netty.handler.codec.base64 Base64]
    [java.io InputStream ByteArrayOutputStream ByteArrayInputStream]
    [java.nio.charset StandardCharsets]
-   [java.net URL URLEncoder UnknownHostException]))
+   [java.net URL URLEncoder URLDecoder UnknownHostException]))
 
 ;; Cheshire is an optional dependency, so we check for it at compile time.
 (def json-enabled?
@@ -166,7 +166,8 @@
      :server-name (.getHost url-parsed)
      :server-port (when-pos (.getPort url-parsed))
      :uri (url-encode-illegal-characters (.getPath url-parsed))
-     :user-info (.getUserInfo url-parsed)
+     :user-info (when-let [user-info (.getUserInfo url-parsed)]
+                  (URLDecoder/decode user-info))
      :query-string (url-encode-illegal-characters (.getQuery url-parsed))}))
 
 (defn- nest-params

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -198,7 +198,7 @@
 
 ;; Statuses for which clj-http will not throw an exception
 (def unexceptional-status?
-  #{200 201 202 203 204 205 206 207 300 301 302 303 307})
+  #{200 201 202 203 204 205 206 207 300 301 302 303 304 307})
 
 ;; helper methods to determine realm of a response
 (defn success?

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -529,11 +529,11 @@
     :or {content-type :x-www-form-urlencoded}
     :as req}]
 
-  (if (and form-params (#{:post :put :patch} request-method))
+  (if (and form-params (#{:post :put :patch :delete} request-method))
     (-> req
-      (dissoc :form-params)
-      (assoc :content-type (content-type-value content-type)
-        :body (coerce-form-params req)))
+        (dissoc :form-params)
+        (assoc :content-type (content-type-value content-type)
+               :body (coerce-form-params req)))
     req))
 
 (defn wrap-url


### PR DESCRIPTION
What was done:

* `DELETE` method is in fact allowed to have form params. Quoting [RFC](https://tools.ietf.org/html/rfc7231#section-4.3.5) "A payload within a DELETE request message has no defined semantics". Meaning it might be there. Current [implementation](https://github.com/dakrone/clj-http/blob/9e89582c1d7f1496a27be474eb7d615fb4a47499/src/clj_http/client.clj#L833) in `clj-http`.

* "304 Not Modified" is `unexceptional-status`, [here](https://github.com/dakrone/clj-http/blob/9e89582c1d7f1496a27be474eb7d615fb4a47499/src/clj_http/client.clj#L203).

* User info is decoded after reading from URL, [here](https://github.com/dakrone/clj-http/blob/9e89582c1d7f1496a27be474eb7d615fb4a47499/src/clj_http/client.clj#L182-L183).