### PR TITLE
Do not use FileRegion when sending file over the pipeline with HttpContentCompressor

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -26,6 +26,7 @@
      Channel ChannelFuture ChannelHandlerContext
      ChannelFutureListener ChannelHandler
      ChannelPipeline]
+    [io.netty.handler.stream ChunkedWriteHandler]
     [io.netty.handler.codec.http
      DefaultFullHttpResponse
      DefaultHttpContent
@@ -425,7 +426,8 @@
             false))
         (.addLast "request-handler" ^ChannelHandler handler)
         (#(when compression?
-            (.addAfter ^ChannelPipeline % "http-server" "deflater" (HttpContentCompressor.))))
+            (.addAfter ^ChannelPipeline %1 "http-server" "deflater" (HttpContentCompressor.))
+            (.addAfter ^ChannelPipeline %1 "deflater" "streamer" (ChunkedWriteHandler.))))
         pipeline-transform))))
 
 ;;;

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -25,7 +25,7 @@
     [io.netty.channel
      Channel ChannelFuture ChannelHandlerContext
      ChannelFutureListener ChannelHandler
-     ChannelPipeline DefaultFileRegion]
+     ChannelPipeline]
     [io.netty.handler.codec.http
      DefaultFullHttpResponse
      DefaultHttpContent

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -41,15 +41,15 @@
 
 (defn http-get
   ([url]
-   (http-get url nil))
+    (http-get url nil))
   ([url options]
-   (http/get url (merge (default-options) {:pool *pool*} options))))
+    (http/get url (merge (default-options) {:pool *pool*} options))))
 
 (defn http-put
   ([url]
-   (http-put url nil))
+    (http-put url nil))
   ([url options]
-   (http/put url (merge (default-options) {:pool *pool*} options))))
+    (http/put url (merge (default-options) {:pool *pool*} options))))
 
 (def port 8082)
 


### PR DESCRIPTION
Covers this [bug](https://github.com/ztellman/aleph/issues/356).

As `FileRegion` does allow to transfer "raw" bytes in an effective way by not copy them from kernel to user-space, we can't apply any transformations, like compression. That's why setting `compression?` to `true` "breaks" sending files.

Proposed solution: when `compression?` is set to `true`, `ChunkedWriteHandler` is added to the pipeline after the deflator. This makes `send-file-body` function to use `send-chunked-file` instead of `send-file-region`. I also updated test cases for server-side compression to check the actual decompressed output, not only headers.