### PR TITLE
Websocket connection to support permessage-deflate compression

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -164,7 +164,8 @@
    | `sub-protocols` | a string with a comma seperated list of supported sub-protocols.
    | `headers` | the headers that should be included in the handshake
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to 65536.
-   | `max-frame-size` | maximum aggregate message size, in bytes, defaults to 1048576."
+   | `max-frame-size` | maximum aggregate message size, in bytes, defaults to 1048576.
+   | `compression?` | when set to `true`, enables client to use per-message deflate compression, defaults to `false`."
   ([url]
     (websocket-client url nil))
   ([url {:keys [raw-stream? insecure? sub-protocols extensions? headers max-frame-payload max-frame-size] :as options}]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -165,7 +165,8 @@
    | `headers` | the headers that should be included in the handshake
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to 65536.
    | `max-frame-size` | maximum aggregate message size, in bytes, defaults to 1048576.
-   | `compression?` | when set to `true`, enables client to use per-message deflate compression, defaults to `false`."
+   | `compression?` | when set to `true`, enables client to use per-message deflate compression, defaults to `false`.
+   | `pipeline-transform` | an optional function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it."
   ([url]
     (websocket-client url nil))
   ([url {:keys [raw-stream? insecure? sub-protocols extensions? headers max-frame-payload max-frame-size] :as options}]

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -165,7 +165,7 @@
    | `headers` | the headers that should be included in the handshake
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to 65536.
    | `max-frame-size` | maximum aggregate message size, in bytes, defaults to 1048576.
-   | `compression?` | when set to `true`, enables client to use per-message deflate compression, defaults to `false`.
+   | `compression?` | when set to `true`, enables client to use permessage-deflate compression extension, defaults to `false`.
    | `pipeline-transform` | an optional function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it."
   ([url]
     (websocket-client url nil))
@@ -182,7 +182,9 @@
    | `headers` | the headers that should be included in the handshake
    | `max-frame-payload` | maximum allowable frame payload length, in bytes, defaults to 65536.
    | `max-frame-size` | maximum aggregate message size, in bytes, defaults to 1048576.
-   | `allow-extensions?` | if true, allows extensions to the WebSocket protocol"
+   | `allow-extensions?` | if true, allows extensions to the WebSocket protocol
+   | `compression?` | when set to `true`, enables permessage-deflate compression extention support for the connection, defaults to `false`.
+   | `pipeline-transform` | an optional function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it."
   ([req]
     (websocket-connection req nil))
   ([req {:keys [raw-stream? headers max-frame-payload max-frame-size allow-extensions?] :as options}]

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -501,10 +501,10 @@
          compression? false}
     :as options}]
   (let [uri (URI. uri)
-        ssl? (= "wss" (.getScheme uri))
+        scheme (.getScheme uri)
+        _ (assert (#{"ws" "wss"} scheme) "scheme must be one of 'ws' or 'wss'")
+        ssl? (= "wss" scheme)
         [s handler] (websocket-client-handler raw-stream? uri sub-protocols extensions? headers max-frame-payload)]
-
-    (assert (#{"ws" "wss"} (.getScheme uri)) "scheme must be one of 'ws' or 'wss'")
 
     (d/chain'
       (netty/create-client

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -485,6 +485,7 @@
            headers
            local-address
            bootstrap-transform
+           pipeline-transform
            epoll?
            sub-protocols
            extensions?
@@ -492,6 +493,7 @@
            max-frame-size
            compression?]
     :or {bootstrap-transform identity
+         pipeline-transform identity
          raw-stream? false
          epoll? false
          sub-protocols nil
@@ -517,7 +519,8 @@
                 (.addLast ^ChannelPipeline %
                           "websocket-deflater"
                           WebSocketClientCompressionHandler/INSTANCE)))
-            (.addLast "handler" ^ChannelHandler handler)))
+            (.addLast "handler" ^ChannelHandler handler)
+            pipeline-transform))
         (when ssl?
           (if insecure?
             (netty/insecure-ssl-client-context)

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -540,12 +540,14 @@
            max-frame-payload
            max-frame-size
            allow-extensions?
-           compression?]
+           compression?
+           pipeline-transform]
     :or {raw-stream? false
          max-frame-payload 65536
          max-frame-size 1048576
          allow-extensions? false
-         compression? false}
+         compression? false
+         pipeline-transform identity}
     :as options}]
 
   (-> req ^AtomicBoolean (.websocket?) (.set true))
@@ -577,6 +579,7 @@
                   (when compression?
                      (.addLast pipeline "websocket-deflater" (WebSocketServerCompressionHandler.)))
                   (.addLast pipeline "websocket-handler" handler)
+                  (pipeline-transform pipeline)
                   s)))
             (d/catch'
               (fn [e]

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -38,7 +38,7 @@
     (d/catch (fn [e] {}))))
 
 (deftest test-echo-handler
-  (with-handler echo-handler
+  (with-both-handlers echo-handler
     (let [c @(http/websocket-client "ws://localhost:8080")]
       (s/put! c "hello")
       (is (= "hello" @(s/try-take! c 5e3))))

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -23,6 +23,10 @@
   `(with-server (http/start-server ~handler {:port 8080, :raw-stream? true})
      ~@body))
 
+(defmacro with-compressing-handler [handler & body]
+  `(with-server (http/start-server ~handler {:port 8080, :compression? true})
+     ~@body))
+
 (defmacro with-both-handlers [handler & body]
   `(do
      (with-handler ~handler ~@body)
@@ -38,4 +42,9 @@
     (let [c @(http/websocket-client "ws://localhost:8080")]
       (s/put! c "hello")
       (is (= "hello" @(s/try-take! c 5e3))))
-    (is (= 400 (:status @(http/get "http://localhost:8080" {:throw-exceptions false}))))))
+    (is (= 400 (:status @(http/get "http://localhost:8080" {:throw-exceptions false})))))
+
+  (with-compressing-handler echo-handler
+    (let [c @(http/websocket-client "ws://localhost:8080")]
+      (s/put! c "hello")
+      (is (= "hello" @(s/try-take! c 5e3))))))

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -44,7 +44,17 @@
       (is (= "hello" @(s/try-take! c 5e3))))
     (is (= 400 (:status @(http/get "http://localhost:8080" {:throw-exceptions false})))))
 
+  (with-both-handlers echo-handler
+    (let [c @(http/websocket-client "ws://localhost:8080" {:compression? true})]
+      (s/put! c "hello with compression enabled")
+      (is (= "hello with compression enabled" @(s/try-take! c 5e3)))))
+
   (with-compressing-handler echo-handler
     (let [c @(http/websocket-client "ws://localhost:8080")]
       (s/put! c "hello")
-      (is (= "hello" @(s/try-take! c 5e3))))))
+      (is (= "hello" @(s/try-take! c 5e3)))))
+  
+  (with-compressing-handler echo-handler
+    (let [c @(http/websocket-client "ws://localhost:8080" {:compression? true})]
+      (s/put! c "hello compressed")
+      (is (= "hello compressed" @(s/try-take! c 5e3))))))


### PR DESCRIPTION
`http/websocket-client` and `http/websocket-connection` now except optional argument `:compression?` to enable [permessage-deflate](https://tools.ietf.org/html/draft-ietf-hybi-permessage-compression-28) extension. 

I also added support for an optional `pipeline-transform` as it's done for HTTP connections. The problem is that It was not even possible to activate extension "manually" as a websocket connect didn't provide any flexibility with channel pipelines. 

/cc https://github.com/ztellman/aleph/issues/304