### PR TITLE
Remove VoidPromise workaround when dealing with pending writes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.22.Final")
+(def netty-version "4.1.23.Final")
 
 (def netty-modules
   '[transport

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -30,8 +30,7 @@
     [io.netty.channel
      Channel
      ChannelHandler ChannelHandlerContext
-     ChannelPipeline
-     VoidChannelPromise]
+     ChannelPipeline]
     [io.netty.handler.codec.http.websocketx
      CloseWebSocketFrame
      PingWebSocketFrame

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -338,17 +338,6 @@
           ;; client handler should take care of the rest
           (netty/close ctx))))
 
-    :write
-    ([_ ctx msg promise]
-      (if-not (instance? VoidChannelPromise promise)
-        (.write ^ChannelHandlerContext ctx msg promise)
-        ;; note that we ignore promise from params on purpose
-        ;; `netty/write` executes all writes with VoidChannelPromise
-        ;; which forces PendingWritesQueue to fail with IllegalStateException
-        ;; (as it does not support void promise) and the error will be
-        ;; lost down the road as we never check if the write succeeded
-        (.write ^ChannelHandlerContext ctx msg)))
-
     :user-event-triggered
     ([this ctx evt]
       (when (instance? ProxyConnectionEvent evt)


### PR DESCRIPTION
As far as this [PR](https://github.com/netty/netty/pull/7780) was accepted and released with Netty 4.1.23, we do not need a manual workaround for VoidPromise instances introduced [here](https://github.com/ztellman/aleph/pull/366)