### PR TITLE
Proxy connection timeout is handled by inbound handler

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -327,7 +327,7 @@
     handler))
 
 (defn pending-proxy-connection-handler [response-stream]
-  (netty/channel-handler
+  (netty/channel-inbound-handler
     :exception-caught
     ([_ ctx cause]
       (if-not (instance? ProxyConnectException cause)


### PR DESCRIPTION
Following up on this: https://github.com/ztellman/aleph/pull/378

As we removed `write` operation from that handler, we can define it as a `ChannelInboundHandler` now.