### PR TITLE
http: name-resolver is never invoked

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -57,7 +57,7 @@
   (let [scheme (.getScheme uri)
         ssl? (= "https" scheme)]
     (-> (client/http-connection
-          (InetSocketAddress.
+          (InetSocketAddress/createUnresolved
             (.getHost uri)
             (int
               (or


### PR DESCRIPTION
Hi,

I was trying to use the async DNS option and hit a little wall. 

```clj
(http/connection-pool {:dns-options {:name-servers ["8.8.4.4"]}})
```

**result**

it continues to use my local setup.

![screenshot from 2018-05-18 11-32-47](https://user-images.githubusercontent.com/1388/40239264-e0289d8c-5ab5-11e8-934b-8eed67289c83.png)

**fix**

in `create-connection`, `(InetSocketAddress. host port)` does the resolution and thus bypasses the name resolver from Netty.

With the following fix, I've got the expected network datagrams.

![screenshot from 2018-05-18 16-08-49](https://user-images.githubusercontent.com/1388/40239369-21f578fc-5ab6-11e8-82aa-ad79c04a23ed.png)
