### PR TITLE
Replacing of header separator with CRLF in multipart

### DIFF
--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -60,12 +60,12 @@
 (defn part-headers [^String part-name ^String mime-type transfer-encoding name]
   (let [cd (str "Content-Disposition: form-data; name=\"" part-name "\""
              (when name (str "; filename=\"" name "\""))
-             \newline)
-        ct (str "Content-Type: " mime-type \newline)
+             "\r\n")
+        ct (str "Content-Type: " mime-type "\r\n")
         cte (if (nil? transfer-encoding)
               ""
-              (str "Content-Transfer-Encoding: " (cc/name transfer-encoding) \newline))]
-    (bs/to-byte-buffer (str cd ct cte \newline))))
+              (str "Content-Transfer-Encoding: " (cc/name transfer-encoding) "\r\n"))]
+    (bs/to-byte-buffer (str cd ct cte "\r\n"))))
 
 (defn encode-part
   "Generates the byte representation of a part for the bytebuffer"
@@ -87,16 +87,16 @@
     (encode-body (boundary) parts))
   ([^String boundary parts]
     (let [b (bs/to-byte-buffer (str "--" boundary))
-          b-len (+ 5 (.length boundary))
+          b-len (+ 6 (.length boundary))
           ps (map #(-> % populate-part encode-part) parts)
           boundaries-len (* (inc (count parts)) b-len)
           part-len (reduce (fn [acc ^ByteBuffer p] (+ acc (.limit p))) 0 ps)
           buf (ByteBuffer/allocate (+ 2 boundaries-len part-len))]
       (.put buf b)
       (doseq [^ByteBuffer part ps]
-        (.put buf (bs/to-byte-buffer "\n"))
+        (.put buf (bs/to-byte-buffer "\r\n"))
         (.put buf part)
-        (.put buf (bs/to-byte-buffer "\n"))
+        (.put buf (bs/to-byte-buffer "\r\n"))
         (.flip b)
         (.put buf b))
       (.put buf (bs/to-byte-buffer "--"))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -41,7 +41,7 @@
     ;; default mime-type
     (is (.contains body-str "Content-Type: application/octet-stream;charset=UTF-8"))
     ;; omitting charset
-    (is (.contains body-str "Content-Type: application/json\n"))
+    (is (.contains body-str "Content-Type: application/json\r\n"))
     ;; mime-type + charset
     (is (.contains body-str "Content-Type: application/xml;charset=ISO-8859-1"))
     ;; filename header
@@ -106,7 +106,7 @@
     (is (.contains body-str "name=\"file.txt\""))
     (is (.contains body-str "filename=\"file.txt\""))
     (is (.contains body-str "filename=\"text-file-to-send.txt\""))
-    (is (.contains body-str "Content-Type: text/plain\n"))
-    (is (.contains body-str "Content-Type: text/plain;charset=UTF-8\n"))
-    (is (.contains body-str "Content-Type: application/png\n"))
-    (is (.contains body-str "Content-Transfer-Encoding: base64\n"))))
+    (is (.contains body-str "Content-Type: text/plain\r\n"))
+    (is (.contains body-str "Content-Type: text/plain;charset=UTF-8\r\n"))
+    (is (.contains body-str "Content-Type: application/png\r\n"))
+    (is (.contains body-str "Content-Transfer-Encoding: base64\r\n"))))


### PR DESCRIPTION
According to [RFC1521](https://www.ietf.org/rfc/rfc1521.txt) (see 7.2.1. Multipart:  The common syntax), header separator must be a CRLF char sequence, so `\newline` in multipart.clj should be replaced with `\r\n`.
Current implementation leads to a problem with e.g. [Apache Commons Multipart](https://git-wip-us.apache.org/repos/asf?p=commons-fileupload.git;a=blob;f=src/main/java/org/apache/commons/fileupload/MultipartStream.java;h=2c58e7e4138feb8dd743253ea68870f8bd7123a3;hb=refs/heads/master#l188). The entire body is interpreted as a header that results in [org.apache.commons.fileupload.MultipartStream$MalformedStreamException](https://git-wip-us.apache.org/repos/asf?p=commons-fileupload.git;a=blob;f=src/main/java/org/apache/commons/fileupload/MultipartStream.java;h=2c58e7e4138feb8dd743253ea68870f8bd7123a3;hb=refs/heads/master#l570).