### PR TITLE
Document aleph.http/request follow-redirects? usage

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -235,7 +235,8 @@
      | `pool-timeout` | timeout in milliseconds for the pool to generate a connection
      | `connection-timeout` | timeout in milliseconds for the connection to become established
      | `request-timeout` | timeout in milliseconds for the arrival of a response over the established connection
-     | `read-timeout` | timeout in milliseconds for the response to be completed"
+     | `read-timeout` | timeout in milliseconds for the response to be completed
+     | `follow-redirects?` | whether to follow redirects, defaults to `true`; see `aleph.http.client-middleware/handle-redirects`"
     [{:keys [pool
              middleware
              pool-timeout
@@ -247,8 +248,7 @@
       :or {pool default-connection-pool
            response-executor default-response-executor
            middleware identity
-           connection-timeout 6e4 ;; 60 seconds
-           follow-redirects? true}
+           connection-timeout 6e4} ;; 60 seconds
       :as req}]
 
     (executor/with-executor response-executor

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -4,7 +4,6 @@
   (:refer-clojure :exclude [update])
   (:require
     [potemkin :as p]
-    [clojure.stacktrace :refer [root-cause]]
     [clojure.string :as str]
     [clojure.walk :refer [prewalk]]
     [manifold.deferred :as d]
@@ -782,7 +781,7 @@
     (write-cookie-header cookies cookie-spec req)))
 
 (defn wrap-cookies
-  "Middleware that set 'Cookie' header based on the contentn of cookies passed
+  "Middleware that set 'Cookie' header based on the content of cookies passed
    with the request or from cookies storage (when provided). Source for 'Cookie'
    header content by priorities:
 

--- a/src/aleph/http/encoding.clj
+++ b/src/aleph/http/encoding.clj
@@ -1,8 +1,7 @@
 (ns aleph.http.encoding
   (:require
     [byte-streams :as bs]
-    [primitive-math :as p]
-    [potemkin :refer [doary]])
+    [primitive-math :as p])
   (:import
     [io.netty.buffer
      ByteBuf


### PR DESCRIPTION
Hi,

Browsing aleph source code, I've discovered that redirects accept extra parameters like `max-redirects` and `force-redirects`. Thus I propose to slightly enhance the documentation so new comers can more easily know about those extra parameters.

While at it, I've removed 2 unused namespaces and fixed a small typo :-)