### PR TITLE
Internal loggers are now singletons

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -85,9 +85,9 @@
 (defn set-logger! [logger]
   (InternalLoggerFactory/setDefaultFactory
     (case logger
-      :log4j (Log4JLoggerFactory.)
-      :slf4j (Slf4JLoggerFactory.)
-      :jdk   (JdkLoggerFactory.))))
+      :log4j Log4JLoggerFactory/INSTANCE
+      :slf4j Slf4JLoggerFactory/INSTANCE
+      :jdk   JdkLoggerFactory/INSTANCE)))
 
 ;;;
 


### PR DESCRIPTION
Creating new instances is deprecated. See https://github.com/netty/netty/blob/400ca8733427732e426d6fa0eb88fcfe7e06b06d/common/src/main/java/io/netty/util/internal/logging/Log4JLoggerFactory.java#L29-L34 for more details.