### PR TITLE
Make sure an empty "Set-Cookie" response header doesn't crash default middleware

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -666,7 +666,7 @@
     :else (>= (System/currentTimeMillis) (+ created max-age))))
 
 (defprotocol CookieSpec
-  "Implement rules for accepting and returing cookies"
+  "Implement rules for accepting and returning cookies"
   (parse-cookie [this cookie-str])
   (write-cookies [this cookies])
   (match-cookie-origin? [this origin cookie]))
@@ -733,7 +733,9 @@
   ([header]
     (decode-set-cookie-header default-cookie-spec header))
   ([cookie-spec header]
-    (netty-cookie->cookie (parse-cookie cookie-spec header))))
+    (some->> header
+             (parse-cookie cookie-spec)
+             (netty-cookie->cookie))))
 
 ;; we might want to use here http/get-all helper,
 ;; but it would result in circular dependencies

--- a/test/aleph/http/client_middleware_test.clj
+++ b/test/aleph/http/client_middleware_test.clj
@@ -113,7 +113,9 @@
                                                      :cookies [{:name "name" :value "John"}]
                                                      :cookie-store cs})
                          (get-in [:headers "cookie"])))
-      "explicitly set cookies override cookie-store even when specified")))
+      "explicitly set cookies override cookie-store even when specified")
+    (is (nil? (middleware/decode-set-cookie-header ""))
+        "empty set-cookie header doesn't crash")))
 
 (defn req->query-string [req]
   (-> (reduce #(%2 %1) req middleware/default-middleware)


### PR DESCRIPTION
It looks like some websites (https://www.leveil.fr for example) sends an empty "Set-Cookie" header, as seen in this curl output

```
*   Trying 212.95.74.7...
* TCP_NODELAY set
* Connected to www.leveil.fr (212.95.74.7) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: *.leveil.fr
* Server certificate: GeoTrust SSL CA - G3
* Server certificate: GeoTrust Global CA
> GET /puy-en-velay/institutions/faits-divers/2018/06/28/la-communication-des-compteurs-linky-stoppee-en-haute-loire_12905252.html HTTP/1.1
> Host: www.leveil.fr
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx/1.10.2
< Date: Thu, 28 Jun 2018 11:41:45 GMT
< Content-Type: text/html;charset=UTF-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< JvmRoute:
< RemoteHost: 52.49.229.26
< X-Do-Gzip: true
< X-Varnish: 1654944425 1654926043
< Via: 1.1 varnish
< Expires: Thu, 28 Jun 2018 11:44:45 GMT
< X-BackEnd: iv3_docker
< X-Restarts: 0
< X-Identity: 127.0.0.1
< X-Host: www.leveil.fr
< X-Sticky:
< X-VI: v
< X-Obj-Hits: 5
< X-Obj-TTL: 75.632
< Set-Cookie:
< Cache-Control: no-cache
< Age: 0
```

In this situation, the client gets a NullPointerException:

```
NullPointerException   aleph.http.client-middleware.Cookie (client_middleware.clj:648)
```

This PR improve support for empty "Set-Cookie" response header.