### PR TITLE
http test: use throw-exceptions without ?

### DIFF
--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -37,7 +37,7 @@
   {:socket-timeout 1e3
    :pool-timeout 1e4
    :request-timeout 1e4
-   :throw-exceptions? false})
+   :throw-exceptions false})
 
 (defn http-get
   ([url]


### PR DESCRIPTION
it seems that there is no `?` everywhere else