### PR TITLE
Bump to Netty 4.1.27.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.25.Final")
+(def netty-version "4.1.27.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Netty 4.1.27.Final has just been released :-)

Changelogs since 4.1.25.Final:

- http://netty.io/news/2018/07/10/4-1-26-Final.html
- http://netty.io/news/2018/07/11/4-1-27-Final.html

Unit tests ran with success.