### PR TITLE
Support custom date header

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -124,9 +124,10 @@
           (when-not (.contains headers ^CharSequence server-name)
             (.set headers ^CharSequence server-name server-value))
 
-          (doto headers
-            (.set ^CharSequence connection-name (if keep-alive? keep-alive-value close-value))
-            (.set ^CharSequence date-name (date-header-value ctx)))
+          (when-not (.contains headers ^CharSequence date-name)
+            (.set headers ^CharSequence date-name (date-header-value ctx)))
+
+          (.set headers ^CharSequence connection-name (if keep-alive? keep-alive-value close-value))
 
           (http/send-message ctx keep-alive? ssl? rsp body))))))
 


### PR DESCRIPTION
Making a similar change that supported a custom server header to a support a custom date header. We use that in test environments to mimic running servers at different times without actually changing the system clock.