### PR TITLE
Bump to Netty 4.1.28.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.27.Final")
+(def netty-version "4.1.28.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Netty 4.1.28.Final is out. Changelog available under http://netty.io/news/2018/07/27/4-1-28-Final.html .