### PR TITLE
Replace HTTP request multipart encoder with Netty's implementation

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -459,13 +459,12 @@
                         (not (.get (.headers req') "Proxy-Connection")))
                   (.set (.headers req') "Proxy-Connection" "Keep-Alive"))
 
-                (if-let [parts (:multipart req)]
-                  ;; xxx: refactoring :(
-                  (let [[req' body] (multipart/encode-request req' parts)]
-                    (netty/safe-execute ch
-                      (http/send-message ch true ssl? req' body)))
+                (let [parts (:multipart req)
+                      [req' body] (if (nil? parts)
+                                    [req' (:body req)]
+                                    (multipart/encode-request req' parts))]
                   (netty/safe-execute ch
-                    (http/send-message ch true ssl? req' (:body req)))))
+                    (http/send-message ch true ssl? req' body))))
 
               ;; this will usually happen because of a malformed request
               (catch Throwable e

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -23,6 +23,7 @@
     [io.netty.handler.codec.http
      DefaultHttpRequest DefaultLastHttpContent
      DefaultHttpResponse DefaultFullHttpRequest
+     FullHttpRequest
      HttpHeaders HttpUtil HttpContent
      HttpMethod HttpRequest HttpMessage
      HttpResponse HttpResponseStatus
@@ -409,6 +410,9 @@
         (handle-cleanup ch f))
 
       f)))
+
+(defn send-full-request [ch keep-alive? ssl? ^FullHttpRequest req]
+  (send-message ch keep-alive? ssl? req (.content req)))
 
 (defn close-on-idle-handler []
   (netty/channel-handler

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -332,7 +332,6 @@
     (netty/write-and-flush ch ci)))
 
 (defn send-chunked-body [ch ^HttpMessage msg ^ChunkedInput body]
-  (assert (chunked-writer-enabled? ch))
   (netty/write ch msg)
   (netty/write-and-flush ch body))
 

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -31,9 +31,9 @@
 (defn mime-type-descriptor
   [^String mime-type ^String encoding]
   (str
-    (-> (or mime-type "application/octet-stream") .trim (.toLowerCase Locale/US))
-    (when encoding
-      (str ";charset=" encoding))))
+   (-> (or mime-type "application/octet-stream") .trim (.toLowerCase Locale/US))
+   (when encoding
+     (str "; charset=" encoding))))
 
 (defn populate-part
   "Generates a part map of the appropriate format"
@@ -118,9 +118,16 @@
     (doseq [{:keys [part-name content mime-type charset name]} parts]
       (if (instance? File content)
         (let [filename (.getName ^File content)
-              name' (or name filename)
-              mt (or mime-type (URLConnection/guessContentTypeFromName filename))]
-          (.addBodyFileUpload encoder part-name name' content mt false))
+              name (or name filename)
+              mime-type (or mime-type
+                            (URLConnection/guessContentTypeFromName filename))
+              content-type (mime-type-descriptor mime-type charset)]
+          (.addBodyFileUpload encoder
+                              part-name
+                              name
+                              content
+                              content-type
+                              false))
         (let [^Charset charset (cond
                                  (nil? charset)
                                  HttpConstants/DEFAULT_CHARSET

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -116,7 +116,6 @@
         (let [filename (.getName ^File content)
               name' (or name filename)
               mt (or mime-type (URLConnection/guessContentTypeFromName filename))]
-          ;; xxx: close files after write is done
           (.addBodyFileUpload encoder part-name name' content mt false))
         ;; xxx: it might be not a string :(
         (let [attr (MemoryAttribute. ^String part-name ^String content)]

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -15,7 +15,8 @@
     [io.netty.util.internal
      ThreadLocalRandom]
     [io.netty.handler.codec.http
-     DefaultHttpRequest]
+     DefaultHttpRequest
+     FullHttpRequest]
     [io.netty.handler.codec.http.multipart
      HttpPostRequestEncoder
      MemoryAttribute]))
@@ -119,4 +120,8 @@
         ;; xxx: it might be not a string :(
         (let [attr (MemoryAttribute. ^String part-name ^String content)]
           (.addBodyHttpData encoder attr))))
-    (.finalizeRequest encoder)))
+    (let [req' (.finalizeRequest encoder)]
+      [req'
+       (if (instance? FullHttpRequest req')
+         (.content ^FullHttpRequest req')
+         encoder)])))

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -92,7 +92,9 @@
       (.put ^ByteBuffer body)
       (.flip))))
 
-(defn encode-body
+(defn
+  ^{:deprecated "use aleph.http.multipart/encode-request instead"}
+  encode-body
   ([parts]
     (encode-body (boundary) parts))
   ([^String boundary parts]

--- a/src/aleph/http/multipart.clj
+++ b/src/aleph/http/multipart.clj
@@ -116,12 +116,10 @@
         (let [filename (.getName ^File content)
               name' (or name filename)
               mt (or mime-type (URLConnection/guessContentTypeFromName filename))]
+          ;; xxx: close files after write is done
           (.addBodyFileUpload encoder part-name name' content mt false))
         ;; xxx: it might be not a string :(
         (let [attr (MemoryAttribute. ^String part-name ^String content)]
           (.addBodyHttpData encoder attr))))
     (let [req' (.finalizeRequest encoder)]
-      [req'
-       (if (instance? FullHttpRequest req')
-         (.content ^FullHttpRequest req')
-         encoder)])))
+      [req' (when (.isChunked encoder) encoder)])))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -118,7 +118,7 @@
 
 (def parts [{:part-name "#0-string"
              :content "CONTENT1"}
-            #_{:part-name "#1-bytes"
+            {:part-name "#1-bytes"
              :content (.getBytes "CONTENT2" "UTF-8")}
             {:part-name "#2-file"
              :content file-to-send}
@@ -145,7 +145,7 @@
 
     ;; contents from a string, bytes, files
     (is (.contains resp "CONTENT1"))
-    #_(.is (.contains resp "CONTENT2"))
+    (is (.contains resp "CONTENT2"))
     (is (.contains resp "this is a file"))
 
     ;; mime types: set explicitly and automatically derived

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -41,11 +41,11 @@
     (is (.contains body-str "content2"))
     (is (.contains body-str "Content-Disposition: form-data;"))
     ;; default mime-type
-    (is (.contains body-str "Content-Type: application/octet-stream;charset=UTF-8"))
+    (is (.contains body-str "Content-Type: application/octet-stream; charset=UTF-8"))
     ;; omitting charset
     (is (.contains body-str "Content-Type: application/json\r\n"))
     ;; mime-type + charset
-    (is (.contains body-str "Content-Type: application/xml;charset=ISO-8859-1"))
+    (is (.contains body-str "Content-Type: application/xml; charset=ISO-8859-1"))
     ;; filename header
     (is (.contains body-str "filename=\"content5.pdf\""))))
 
@@ -109,7 +109,7 @@
     (is (.contains body-str "filename=\"file.txt\""))
     (is (.contains body-str "filename=\"text-file-to-send.txt\""))
     (is (.contains body-str "Content-Type: text/plain\r\n"))
-    (is (.contains body-str "Content-Type: text/plain;charset=UTF-8\r\n"))
+    (is (.contains body-str "Content-Type: text/plain; charset=UTF-8\r\n"))
     (is (.contains body-str "Content-Type: application/png\r\n"))
     (is (.contains body-str "Content-Transfer-Encoding: base64\r\n"))))
 
@@ -127,7 +127,10 @@
              :content file-to-send}
             {:part-name "#4-file-with-name"
              :name "text-file-to-send.txt"
-             :content file-to-send}])
+             :content file-to-send}
+            {:part-name "#5-file-with-charset"
+             :content file-to-send
+             :charset "ISO-8859-1"}])
 
 (defn echo-handler [{:keys [body]}]
   {:status 200
@@ -152,6 +155,7 @@
     (is (.contains resp "content-type: text/plain"))
     (is (.contains resp "content-type: application/png"))
     (is (.contains resp "; charset=UTF-8"))
+    (is (.contains resp "; charset=ISO-8859-1"))
 
     ;; explicit filename
     (is (.contains resp "filename=\"text-file-to-send.txt\""))

--- a/test/aleph/http/multipart_test.clj
+++ b/test/aleph/http/multipart_test.clj
@@ -1,12 +1,14 @@
 (ns aleph.http.multipart-test
   (:use
-    [clojure test])
+   [clojure test])
   (:require
-    [aleph.http.multipart :as mp]
-    [byte-streams :as bs])
+   [aleph.http :as http]
+   [aleph.http.multipart :as mp]
+   [byte-streams :as bs]
+   [manifold.deferred :as d])
   (:import
-    [java.io
-     File]))
+   [java.io
+    File]))
 
 (def file-to-send (File. (str (System/getProperty "user.dir") "/test/file.txt")))
 
@@ -110,3 +112,48 @@
     (is (.contains body-str "Content-Type: text/plain;charset=UTF-8\r\n"))
     (is (.contains body-str "Content-Type: application/png\r\n"))
     (is (.contains body-str "Content-Transfer-Encoding: base64\r\n"))))
+
+(def port 26003)
+(def url (str "http://localhost:" port))
+
+(def parts [{:part-name "#0-string"
+             :content "CONTENT1"}
+            #_{:part-name "#1-bytes"
+             :content (.getBytes "CONTENT2" "UTF-8")}
+            {:part-name "#2-file"
+             :content file-to-send}
+            {:part-name "#3-file-with-mime-type"
+             :mime-type "application/png"
+             :content file-to-send}
+            {:part-name "#4-file-with-name"
+             :name "text-file-to-send.txt"
+             :content file-to-send}])
+
+(defn echo-handler [{:keys [body]}]
+  {:status 200
+   :body body})
+
+(deftest test-send-multipart-request
+  (let [s (http/start-server echo-handler {:port port})
+        ^String resp @(d/chain'
+                       (http/post url {:multipart parts})
+                       :body
+                       bs/to-string)]
+    ;; part names
+    (doseq [{:keys [part-name]} parts]
+      (is (.contains resp (str "name=\"" part-name "\""))))
+
+    ;; contents from a string, bytes, files
+    (is (.contains resp "CONTENT1"))
+    #_(.is (.contains resp "CONTENT2"))
+    (is (.contains resp "this is a file"))
+
+    ;; mime types: set explicitly and automatically derived
+    (is (.contains resp "content-type: text/plain"))
+    (is (.contains resp "content-type: application/png"))
+    (is (.contains resp "; charset=UTF-8"))
+
+    ;; explicit filename
+    (is (.contains resp "filename=\"text-file-to-send.txt\""))
+
+    (.close ^java.io.Closeable s)))


### PR DESCRIPTION
Pros:

* heavily tested encoder
* support for chunked input without a necessity to read everything into memory right away
* easily might be extended to support `multipart/mixed`, not only `multipart/form-data`

Cons:

* custom transfer encodings are not supported right now, only `binary` and plain text (to add `base64` or `qp` we need to extend Netty's implementation first)