### PR TITLE
Bump to Netty 4.1.29.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.28.Final")
+(def netty-version "4.1.29.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Netty 4.1.29.Final is out. Changelog can be found under http://netty.io/news/2018/08/24/4-1-29-Final.html