### PR TITLE
Bump to Netty 4.1.30.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.29.Final")
+(def netty-version "4.1.30.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Netty 4.1.30 is out. Changes are available under https://netty.io/news/2018/09/28/4-1-30-Final.html

There is an interesting ByteBuf performance improvements announced.