### PR TITLE
Add :ssl? option to HTTP start-server.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
     [byte-streams "0.2.5-alpha2"]
     [potemkin "0.4.5"]])
 
-(defproject aleph "0.4.7-alpha2"
+(defproject aleph "0.4.7-alpha2-mpp"
   :description "a framework for asynchronous communication"
   :repositories {"jboss" "https://repository.jboss.org/nexus/content/groups/public/"
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
     [byte-streams "0.2.5-alpha2"]
     [potemkin "0.4.5"]])
 
-(defproject aleph "0.4.7-alpha2-mpp"
+(defproject aleph "0.4.7-alpha2"
   :description "a framework for asynchronous communication"
   :repositories {"jboss" "https://repository.jboss.org/nexus/content/groups/public/"
                  "sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"}

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -33,6 +33,7 @@
    | `socket-address` |  a `java.net.SocketAddress` specifying both the port and interface to bind to.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object if an SSL connection is desired |
+   | `ssl?` | set to `true` to indicate that SSL is active, but the caller is managing it (this implies `:ssl-context` is nil). For example, this can be used if you want to use configure SNI (perhaps in `:pipeline-transform`) to select the SSL context based on the client's indicated host name. |
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `executor` | a `java.util.concurrent.Executor` which is used to handle individual requests.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
    | `shutdown-executor?` | if `true`, the executor will be shut down when `.close()` is called on the server, defaults to `true`.

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -33,7 +33,7 @@
    | `socket-address` |  a `java.net.SocketAddress` specifying both the port and interface to bind to.
    | `bootstrap-transform` | a function that takes an `io.netty.bootstrap.ServerBootstrap` object, which represents the server, and modifies it.
    | `ssl-context` | an `io.netty.handler.ssl.SslContext` object if an SSL connection is desired |
-   | `ssl?` | set to `true` to indicate that SSL is active, but the caller is managing it (this implies `:ssl-context` is nil). For example, this can be used if you want to use configure SNI (perhaps in `:pipeline-transform`) to select the SSL context based on the client's indicated host name. |
+   | `manual-ssl?` | set to `true` to indicate that SSL is active, but the caller is managing it (this implies `:ssl-context` is nil). For example, this can be used if you want to use configure SNI (perhaps in `:pipeline-transform`) to select the SSL context based on the client's indicated host name. |
    | `pipeline-transform` | a function that takes an `io.netty.channel.ChannelPipeline` object, which represents a connection, and modifies it.
    | `executor` | a `java.util.concurrent.Executor` which is used to handle individual requests.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread.
    | `shutdown-executor?` | if `true`, the executor will be shut down when `.close()` is called on the server, defaults to `true`.

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -447,7 +447,7 @@
            bootstrap-transform
            pipeline-transform
            ssl-context
-           ssl?
+           manual-ssl?
            shutdown-executor?
            epoll?
            compression?]
@@ -478,7 +478,7 @@
       (pipeline-builder
         handler
         pipeline-transform
-        (assoc options :executor executor :ssl? (or ssl? (boolean ssl-context))))
+        (assoc options :executor executor :ssl? (or manual-ssl? (boolean ssl-context))))
       ssl-context
       bootstrap-transform
       (when (and shutdown-executor? (instance? ExecutorService executor))

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -447,6 +447,7 @@
            bootstrap-transform
            pipeline-transform
            ssl-context
+           ssl?
            shutdown-executor?
            epoll?
            compression?]
@@ -477,7 +478,7 @@
       (pipeline-builder
         handler
         pipeline-transform
-        (assoc options :executor executor :ssl? (boolean ssl-context)))
+        (assoc options :executor executor :ssl? (or ssl? (boolean ssl-context))))
       ssl-context
       bootstrap-transform
       (when (and shutdown-executor? (instance? ExecutorService executor))


### PR DESCRIPTION
Hi Zach, I've just had a frustrating few hours trying to add SNI support to an Aleph-based HTTP server using `io.netty.handler.ssl SniHandler`. I was adding a `SslContext` via Aleph's `:ssl-context` option so that Aleph would configure correctly for SSL, then removing it in the pipeline-transform and adding the SNI handler.

Unfortunately if you do this the removed `SSLHandler` times out on the SSL handshake 10 seconds later and silently closes the connection! I'd say this is a bug in `SslHandler`, but it's still sub-optimal to be creating and then tossing `SslHandler`'s this way. So I thought a simple way to enable this was to allow clients to specify the `:ssl?` option directly, and then take responsibility for actually setting up the context themselves.

It'd be great if you think this is an good solution, but I'm also open to other ways to do this.

Cheers,

Matt.

PS. and thanks for Manifold and Aleph! They're amazingly clever and useful pieces of kit.