### PR TITLE
Fix ExceptionInInitializerError in reified GenericFutureListener 

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -198,9 +198,8 @@
             ;; on a Netty thread that doesn't have appropriate class loader
             ;; more information here:
             ;; https://github.com/ztellman/aleph/issues/365
-            class-loader (if (.isBound clojure.lang.Compiler/LOADER)
-                           (.deref clojure.lang.Compiler/LOADER)
-                           (clojure.lang.RT/makeClassLoader))]
+            class-loader (or (clojure.lang.RT/baseLoader)
+                             (clojure.lang.RT/makeClassLoader))]
         (.addListener f
           (reify GenericFutureListener
             (operationComplete [_ _]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -193,24 +193,37 @@
   (when f
     (if (.isSuccess f)
       (d/success-deferred (.getNow f) nil)
-      (let [d (d/deferred nil)]
+      (let [d (d/deferred nil)
+            ;; workaround for the issue with executing RT.readString
+            ;; on a Netty thread that doesn't have appropriate class loader
+            ;; more information here:
+            ;; https://github.com/ztellman/aleph/issues/365
+            class-loader (if (.isBound clojure.lang.Compiler/LOADER)
+                           (.deref clojure.lang.Compiler/LOADER)
+                           (clojure.lang.RT/makeClassLoader))]
         (.addListener f
           (reify GenericFutureListener
             (operationComplete [_ _]
-              (cond
-                (.isSuccess f)
-                (d/success! d (.getNow f))
+              (try
+                (. clojure.lang.Var
+                   (pushThreadBindings {clojure.lang.Compiler/LOADER
+                                        class-loader}))
+                (cond
+                  (.isSuccess f)
+                  (d/success! d (.getNow f))
 
-                (.isCancelled f)
-                (d/error! d (CancellationException. "future is cancelled."))
+                  (.isCancelled f)
+                  (d/error! d (CancellationException. "future is cancelled."))
 
-                (some? (.cause f))
-                (if (instance? java.nio.channels.ClosedChannelException (.cause f))
-                  (d/success! d false)
-                  (d/error! d (.cause f)))
+                  (some? (.cause f))
+                  (if (instance? java.nio.channels.ClosedChannelException (.cause f))
+                    (d/success! d false)
+                    (d/error! d (.cause f)))
 
-                :else
-                (d/error! d (IllegalStateException. "future in unknown state"))))))
+                  :else
+                  (d/error! d (IllegalStateException. "future in unknown state")))
+                (finally
+                  (. clojure.lang.Var (popThreadBindings)))))))
         d))))
 
 (defn allocate [x]


### PR DESCRIPTION
The issue was mentioned [here](https://github.com/ztellman/aleph/issues/365#issuecomment-378416967) and [here](https://github.com/ztellman/aleph/pull/406#issuecomment-434446433).

**The root of the problem:**

[Here](https://github.com/ztellman/manifold/blob/d67a8c1b9f1268c094895d70dbbf146521f5774b/src/manifold/deferred.clj#L281-L293) we have a `try-catch` block that compiles to a separate class `Deferred$fn__**` to be lately instanciated (and invoked) in `Deferred.success`. The class contains a static variable with `RT.readString` of the `ns` declaration, I assume that comes from a `clojure.tools.logging` toolchain. The problem is that our first attempt to use this class happens on a Netty's thread (`globalEventExecutor-**` created by [this](https://github.com/netty/netty/blob/00afb19d7a37de21b35ce4f6cb3fa7f74809f2ab/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java#L58-L59) factory to be more specific) and... there's no appropriate class loader there. `RT.baseLoader` function [here](https://github.com/clojure/clojure/blob/a1722cf9a15d917ee78a117732cf5c5e01fe3557/src/jvm/clojure/lang/RT.java#L2176-L2177) falls back to a current thread context loader (because of the default value of `*use-context-classloader*` set to `true`) which is set to `NULL` on Netty's threads.

**The solution:**

The simplest thing we can do here is to carry class loader in a closure (either current loader from a thread local Clojure frame or newly created). I'm also going to submit a PR to `manifold` to set an appropriate class loader to each new thread created by [this](https://github.com/ztellman/manifold/blob/master/src/manifold/executor.clj#L43) factory. It will reduce the number of calls to `RT.makeClassLoader` as we need to do this only once per thread. 

I've been also thinking if it's worth the effort to try to submit an issue to Clojure JIRA with the problem definition but now I doubt if it's necessary. Being pessimistically careful here would introduce some performance penalties in a lot of places when in fact the code that was invoked from a non-Clojure thread is not that wide-spread pattern. And it's hard for the compiler to distinguish such cases in advanced. There're still a lot of improvements might be done at least to eliminate unnecessary calls to a reader.. but that's for sure a completely separate topic.

P.S. Submitting this a separate PR not to mess up with tons of changes from #406.