### PR TITLE
Minor fixes in client_middleware.clj

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -1,7 +1,6 @@
 (ns aleph.http.client-middleware
   "This middleware is adapted from clj-http, whose license is amenable to this sort of
    copy/pastery"
-  (:refer-clojure :exclude [update])
   (:require
     [potemkin :as p]
     [clojure.string :as str]
@@ -110,25 +109,8 @@
 
 ;;;
 
-(defn update [m k f & args]
-  (assoc m k (apply f (m k) args)))
-
 (defn when-pos [v]
   (when (and v (pos? v)) v))
-
-(defn dissoc-in
-  "Dissociates an entry from a nested associative structure returning a new
-  nested structure. keys is a sequence of keys. Any empty maps that result
-  will not be present in the new structure."
-  [m [k & ks :as keys]]
-  (if ks
-    (if-let [nextmap (clojure.core/get m k)]
-      (let [newmap (dissoc-in nextmap ks)]
-        (if (seq newmap)
-          (assoc m k newmap)
-          (dissoc m k)))
-      m)
-    (dissoc m k)))
 
 (defn url-encode
   ([s]

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -949,7 +949,7 @@
               ;; coerce the response body
               (fn [{:keys [body] :as rsp}]
                 (let [rsp' (handle-response-debug req' rsp)]
-                  (if (nil? body)
-                    rsp'
+                  (if (and (some? body) (some? (:as req')))
                     (d/future-with (or executor (ex/wait-pool))
-                      (coerce-response-body req' rsp'))))))))))))
+                      (coerce-response-body req' rsp'))
+                    rsp'))))))))))

--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -252,9 +252,9 @@
     type))
 
 (defn wrap-exceptions
-  "Middleware that throws a slingshot exception if the response is not a
-  regular response. If :throw-entire-message? is set to true, the entire
-  response is used as the message, instead of just the status number."
+  "Middleware that throws response as an ExceptionInfo if the response has
+  unsuccessful status code. :throw-exceptions set to false in the request
+  disables this middleware."
   [client]
   (fn [req]
     (d/let-flow' [{:keys [status body] :as rsp} (client req)]


### PR DESCRIPTION
1. Looks like there were some leftovers in the docstring from the time when Aleph used Slingshot.
2. I took the liberty of removing a few currently unused functions. I will drop this commit if they are still needed.
3. Since by default the requests don't have `:as` key (as I understand, it has to be provided explicitly), in common case `coerce-response-body` will do nothing, which makes it unnecessary to put it on the executor in such case.