### PR TITLE
Carefully release ByteBuf when processing WebSocketFrame

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -534,33 +534,44 @@
 
        :channel-read
        ([_ ctx msg]
-         (try
-           (let [ch (.channel ctx)]
-             (if-not (instance? WebSocketFrame msg)
-               (.fireChannelRead ctx msg)
-               (let [^WebSocketFrame msg msg]
-                 (cond
+         (let [ch (.channel ctx)]
+           (if-not (instance? WebSocketFrame msg)
+             ;; no need to release buffer when passing to a next handler
+             (.fireChannelRead ctx msg)
+             (let [^WebSocketFrame msg msg]
+               (cond
 
-                   (instance? TextWebSocketFrame msg)
-                   (netty/put! ch in (.text ^TextWebSocketFrame msg))
+                 (instance? TextWebSocketFrame msg)
+                 (let [text (.text ^TextWebSocketFrame msg)]
+                   ;; working with text now, so we do not need
+                   ;; ByteBuf inside TextWebSocketFrame
+                   ;; note, that all *WebSocketFrame classes are
+                   ;; subclasses of DefaultByteBufHolder, meaning
+                   ;; there's no difference between releasing
+                   ;; frame & frame's content
+                   (netty/release msg)
+                   (netty/put! ch in text))
 
-                   (instance? BinaryWebSocketFrame msg)
-                   (let [body (.content ^BinaryWebSocketFrame msg)]
-                     (netty/put! ch in
-                       (if raw-stream?
-                         (netty/acquire body)
-                         (netty/buf->array body))))
+                 (instance? BinaryWebSocketFrame msg)
+                 (let [body (.content ^BinaryWebSocketFrame msg)]
+                   (netty/put! ch in
+                     (if raw-stream?
+                       body
+                       ;; copied data into byte array, deallocating ByteBuf
+                       (netty/release-buf->array body))))
 
-                   (instance? PingWebSocketFrame msg)
-                   (netty/write-and-flush ch (PongWebSocketFrame. (netty/acquire (.content msg))))
+                 (instance? PingWebSocketFrame msg)
+                 (let [body (.content ^PingWebSocketFrame msg)]
+                   ;; reusing the same buffer
+                   ;; will be deallocated by Netty
+                   (netty/write-and-flush ch (PongWebSocketFrame. body)))
 
-                   (instance? CloseWebSocketFrame msg)
-                   (.close handshaker ch (netty/acquire msg))
+                 (instance? CloseWebSocketFrame msg)
+                 (.close handshaker ch msg)
 
-                   :else
-                   (.fireChannelRead ctx msg)))))
-           (finally
-             (netty/release msg)))))]))
+                 :else
+                 ;; no need to release buffer when passing to a next handler
+                 (.fireChannelRead ctx msg)))))))]))
 
 ;; note, as we set `keep-alive?` to `false`, `send-message` will close the connection
 ;; after writes are done, which is exactly what we expect to happen

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -567,6 +567,8 @@
                    (netty/write-and-flush ch (PongWebSocketFrame. body)))
 
                  (instance? CloseWebSocketFrame msg)
+                 ;; reusing the same buffer
+                 ;; will be deallocated by Netty
                  (.close handshaker ch msg)
 
                  :else

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -119,9 +119,10 @@
     (.array dst)))
 
 (defn release-buf->array [^ByteBuf buf]
-  (let [ary (buf->array buf)]
-    (release buf)
-    ary))
+  (try
+    (buf->array buf)
+    (finally
+      (release buf))))
 
 (defn bufs->array [bufs]
   (let [bufs' (mapcat #(.nioBuffers ^ByteBuf %) bufs)


### PR DESCRIPTION
Trying to catch #428. Left a few notes/comments in the code.

@ztellman Seems more reasonable now, but it obviously requires a double-check. 