### PR TITLE
Bump to Netty 4.1.32.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.31.Final")
+(def netty-version "4.1.32.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Changelog available under https://netty.io/news/2018/11/29/4-1-32-Final.html