### PR TITLE
Avoid reflection when calling java.net.URLEncoder/encode on JDK11

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -131,9 +131,9 @@
     (dissoc m k)))
 
 (defn url-encode
-  ([s]
+  ([^String s]
     (url-encode s "UTF-8"))
-  ([s encoding]
+  ([^String s ^String encoding]
     (URLEncoder/encode s encoding)))
 
 (let [param-? (memoize #(keyword (str (name %) "?")))]


### PR DESCRIPTION
On JDK11

```clojure
user=> (require '[aleph.http :as http])
Reflection warning, aleph/http/client_middleware.clj:137:5 - call to static method encode on java.net.URLEncoder can't be resolved (argument types: unknown, unknown).
nil
```