### PR TITLE
Avoid releasing non reference counted request body

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -181,7 +181,6 @@
         netty/wrap-future
         (fn [_]
           (netty/release req)
-          (netty/release body)
           (-> rsp
             (d/catch' error-response)
             (d/chain'


### PR DESCRIPTION
Request body might be on of the following:

* `nil`
* `java.io.ByteArrayInputStream`
* `manifold.stream.BufferedStream`

None of that implements `io.netty.util.ReferenceCounted` interface.