### PR TITLE
Use defonce to prevent rebinding of thread locals

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -69,8 +69,8 @@
 
 ;;;
 
-(def ^FastThreadLocal date-format (FastThreadLocal.))
-(def ^FastThreadLocal date-value (FastThreadLocal.))
+(defonce ^FastThreadLocal date-format (FastThreadLocal.))
+(defonce ^FastThreadLocal date-value (FastThreadLocal.))
 
 (defn rfc-1123-date-string []
   (let [^DateFormat format


### PR DESCRIPTION
Not a huge issue for production, but kinda annoying in testing/development. Right now each time we reload `aleph.http.server` module we get new `FastThreadLocal` objects while threads are still running, which leads to ghost `scheduleAtFixedRate` loops on Netty's executor.