### PR TITLE
Honour -Dio.netty.eventLoopThreads property when creating a server

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -924,8 +924,7 @@
    on-close
    ^SocketAddress socket-address
    epoll?]
-  (let [num-cores      (.availableProcessors (Runtime/getRuntime))
-        num-threads    (* 2 num-cores)
+  (let [num-threads    (get-default-event-loop-threads)
         thread-factory (enumerating-thread-factory "aleph-netty-server-event-pool" false)
         closed?        (atom false)
 


### PR DESCRIPTION
Right now, Aleph uses -Dio.netty.eventLoopThreads Java property when creating an EventLoop for a client, and ignores it for the server. Not sure if this is intended, and if it is – it could use a comment about the reasons; otherwise, it makes sense to fix this for consistency.