### PR TITLE
Use volatile! instead of atoms for internal states in handlers

### DIFF
--- a/src/aleph/http/client_middleware.clj
+++ b/src/aleph/http/client_middleware.clj
@@ -908,10 +908,10 @@
 (defn wrap-request-debug [req]
   (cond-> req
     (opt req :save-request)
-    (assoc :aleph/save-request-message (atom nil))
+    (assoc :aleph/save-request-message (volatile! nil))
 
     (opt req :debug-body)
-    (assoc :aleph/save-request-body (atom nil))))
+    (assoc :aleph/save-request-body (volatile! nil))))
 
 (defn handle-response-debug [req rsp]
   (let [saved-message (get req :aleph/save-request-message)


### PR DESCRIPTION
Mentioned in #451. It looks like all access to the internals of handlers should be sequential. If I'm not missing anything...