### PR TITLE
Use Epoll datagram channel for DNS resolver group when running on Epoll

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -154,9 +154,14 @@
      (IllegalArgumentException.
       ":idle-timeout option is not allowed when :keep-alive? is explicitly disabled")))
 
-  (let [conn-options' (cond-> connection-options
-                        (some? dns-options)
-                        (assoc :name-resolver (netty/dns-resolver-group dns-options)))
+  (let [dns-options' (if-not (and (some? dns-options)
+                                  (not (contains? dns-options :epoll?)))
+                       dns-options
+                       (let [epoll? (:epoll? connection-options false)]
+                         (assoc dns-options :epoll? epoll?)))
+        conn-options' (cond-> connection-options
+                        (some? dns-options')
+                        (assoc :name-resolver (netty/dns-resolver-group dns-options')))
         p (promise)
         pool (flow/instrumented-pool
                {:generate (fn [host]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -830,17 +830,12 @@
          decode-idn? true
          recursion-desired? true
          epoll? false}}]
-  (let [^EventLoopGroup
-        client-group (if (and epoll? (epoll-available?))
-                       @epoll-client-group
-                       @nio-client-group)
-
-        ^Class
+  (let [^Class
         channel-type (if (and epoll? (epoll-available?))
                        EpollDatagramChannel
                        NioDatagramChannel)
 
-        b (cond-> (doto (DnsNameResolverBuilder. (.next client-group))
+        b (cond-> (doto (DnsNameResolverBuilder.)
                     (.channelType channel-type)
                     (.maxPayloadSize max-payload-size)
                     (.maxQueriesPerResolve max-queries-per-resolve)

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -802,7 +802,8 @@
    | `ndots` | sets the number of dots which must appear in a name before an initial absolute query is made, defaults to `-1`
    | `decode-idn?` | set if domain / host names should be decoded to unicode when received, defaults to `true`
    | `recursion-desired?` | if set to `true`, the resolver sends a DNS query with the RD (recursion desired) flag set, defaults to `true`
-   | `name-servers` | optional list of DNS server addresses, automatically discovered when not set (platform dependent)"
+   | `name-servers` | optional list of DNS server addresses, automatically discovered when not set (platform dependent)
+   | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`"
   [{:keys [max-payload-size
            max-queries-per-resolve
            address-types


### PR DESCRIPTION
Fixes #476.

It also extends DNS options with new `:epoll?` setting.