### PR TITLE
Fine-grained websocket close handshake API

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -249,15 +249,12 @@
    client waits for the connection to be closed by the server (no longer than close handshake
    timeout, see websocket connection configuration for more details)."
   ([conn]
-   (websocket-close! conn 1000 "" nil))
+   (websocket-close! conn http-core/close-empty-status-code "" nil))
   ([conn status-code]
    (websocket-close! conn status-code "" nil))
   ([conn status-code reason-text]
    (websocket-close! conn status-code reason-text nil))
   ([conn status-code reason-text deferred]
-   (when-not (<= 1000 status-code 4999)
-     (throw (IllegalArgumentException.
-             "websocket status code should be in range 1000-4999")))
    (let [d' (or deferred (d/deferred))]
      (http-core/websocket-close! conn status-code reason-text d'))))
 

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -241,6 +241,24 @@
   ([conn d' data]
    (http-core/websocket-ping conn d' data)))
 
+(defn websocket-close!
+  "Closes given websocket endpoint (either client or server) sending Close frame with provided
+   status code and reason text. Returns a deferred that will yield true whenever the connection was
+   closed after the successful write or false if it was already closed. Note, that for the server
+   closes the connection right after Close frame was flushed but the client waits for the connection
+   to be closed by the server (not longer than close handshake timeout)."
+  ([conn]
+   (websocket-close! conn 1000 "" nil))
+  ([conn status-code]
+   (websocket-close! conn status-code "" nil))
+  ([conn status-code reason-text]
+   (websocket-close! conn status-code reason-text nil))
+  ([conn status-code reason-text deferred]
+   (when-not (<= 1000 status-code 4999)
+     (throw (IllegalArgumentException.
+             "websocket status code should be in range 1000-4999")))
+   (http-core/websocket-close! conn status-code reason-text deferred)))
+
 (let [maybe-timeout! (fn [d timeout] (when d (d/timeout! d timeout)))]
   (defn request
     "Takes an HTTP request, as defined by the Ring protocol, with the extensions defined

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -258,7 +258,8 @@
    (when-not (<= 1000 status-code 4999)
      (throw (IllegalArgumentException.
              "websocket status code should be in range 1000-4999")))
-   (http-core/websocket-close! conn status-code reason-text deferred)))
+   (let [d' (or deferred (d/deferred))]
+     (http-core/websocket-close! conn status-code reason-text d'))))
 
 (let [maybe-timeout! (fn [d timeout] (when d (d/timeout! d timeout)))]
   (defn request

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -243,10 +243,11 @@
 
 (defn websocket-close!
   "Closes given websocket endpoint (either client or server) sending Close frame with provided
-   status code and reason text. Returns a deferred that will yield true whenever the connection was
-   closed after the successful write or false if it was already closed. Note, that for the server
-   closes the connection right after Close frame was flushed but the client waits for the connection
-   to be closed by the server (not longer than close handshake timeout)."
+   status code and reason text. Returns a deferred that will yield `true` whenever the closing
+   handshake was initiated with given params or `false` if the connection was already closed.
+   Note, that for the server closes the connection right after Close frame was flushed but the
+   client waits for the connection to be closed by the server (no longer than close handshake
+   timeout, see websocket connection configuration for more details)."
   ([conn]
    (websocket-close! conn 1000 "" nil))
   ([conn status-code]

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -637,7 +637,8 @@
          handshaker (websocket-handshaker uri
                                           sub-protocols
                                           extensions?
-                                          headers max-frame-payload)
+                                          headers
+                                          max-frame-payload)
          closing? (AtomicBoolean. false)]
 
      [d

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -713,7 +713,10 @@
                       ;; handle handshake exception
                       (d/error! d ex)
                       (s/close! @in)
-                      (netty/close ctx))))
+                      (netty/close ctx)))
+                (d/finally'
+                  (fn []
+                    (netty/release msg))))
 
             (instance? FullHttpResponse msg)
             (let [rsp ^FullHttpResponse msg

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -650,8 +650,8 @@
        ([_ ctx]
         (when (realized? d)
           ;; close only on success
-          (d/chain' d s/close!))
-        (http/resolve-pings! pending-pings false)
+          (d/chain' d s/close!)
+          (http/resolve-pings! pending-pings false))
         (.fireChannelInactive ctx))
 
        :channel-active

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -686,7 +686,9 @@
                  (fn [_]
                    (let [close-fn (fn [^CloseWebSocketFrame frame]
                                     (if-not (.compareAndSet closing? false true)
-                                      false
+                                      (do
+                                        (netty/release frame)
+                                        false)
                                       (do
                                         (-> (.close handshaker ch frame)
                                             netty/wrap-future

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -477,8 +477,9 @@
            ;; function that meant to be a stateless coercer
            (when-not (d/realized? (.-deferred msg))
              (d/success! (.-deferred msg) succeed?))
-           ;; no need to write anything here
-           nil))
+           ;; we want to close the sink here to stop accepting
+           ;; new messages from the user
+           netty/sink-close-marker))
 
        CharSequence
        (TextWebSocketFrame. (bs/to-string msg))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -41,7 +41,8 @@
      WebSocketFrame
      PingWebSocketFrame
      TextWebSocketFrame
-     BinaryWebSocketFrame]
+     BinaryWebSocketFrame
+     CloseWebSocketFrame]
     [java.io
      File
      RandomAccessFile

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -469,8 +469,8 @@
        WebsocketClose
        (when (some? close-handshake-fn)
          (let [^WebsocketClose msg msg
-               frame (CloseWebSocketFrame. (.-status-code msg)
-                                           (.-reason-text msg))
+               frame (CloseWebSocketFrame. ^int (.-status-code msg)
+                                           ^String (.-reason-text msg))
                succeed? (close-handshake-fn frame)]
            ;; it still feels somewhat clumsy to make concurrent
            ;; updates and realized deferred from internals of the

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -496,10 +496,11 @@
         payload (aleph.http.core/WebsocketClose. d' status-code reason-text)]
     (d/chain'
      (s/put! conn payload)
-     #(when (and (false? %) (not (d/realized? d')))
-        ;; if the stream does not accept new messages,
-        ;; connection is already closed
-        (d/success! d' false)))
+     (fn [put?]
+       (when (and (false? put?) (not (d/realized? d')))
+         ;; if the stream does not accept new messages,
+         ;; connection is already closed
+         (d/success! d' false))))
     d'))
 
 (defn attach-heartbeats-handler [^ChannelPipeline pipeline heartbeats]

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -477,9 +477,11 @@
            ;; function that meant to be a stateless coercer
            (when-not (d/realized? (.-deferred msg))
              (d/success! (.-deferred msg) succeed?))
+
            ;; we want to close the sink here to stop accepting
            ;; new messages from the user
-           netty/sink-close-marker))
+           (when succeed?
+             netty/sink-close-marker)))
 
        CharSequence
        (TextWebSocketFrame. (bs/to-string msg))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -492,8 +492,7 @@
   d')
 
 (defn websocket-close! [conn status-code reason-text d']
-  (let [d' (or deferred (d/deferred))
-        payload (aleph.http.core/WebsocketClose. d' status-code reason-text)]
+  (let [payload (aleph.http.core/WebsocketClose. d' status-code reason-text)]
     (d/chain'
      (s/put! conn payload)
      (fn [put?]

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -504,8 +504,12 @@
          coerce-fn (http/websocket-message-coerce-fn
                     ch
                     pending-pings
-                    closing?
-                    #(.close handshaker ch ^CloseWebSocketFrame %))
+                    (fn [^CloseWebSocketFrame frame]
+                      (if-not (compare-and-set! closing? false true)
+                        false
+                        (do
+                          (.close handshaker ch frame)
+                          true))))
          out (netty/sink ch false coerce-fn)
          in (netty/buffered-source ch (constantly 1) 16)]
 

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -505,7 +505,7 @@
                     ch
                     pending-pings
                     (fn [^CloseWebSocketFrame frame]
-                      (if-not (compare-and-set! closing? false true)
+                      (if-not (.compareAndSet closing? false true)
                         false
                         (do
                           (.close handshaker ch frame)
@@ -523,7 +523,7 @@
       ;; in that case *out* would be closed earlier and the underlying
       ;; netty channel is already terminated
       #(when (and (.isOpen ch)
-                  (compare-and-set! closing? false true))
+                  (.compareAndSet closing? false true))
          (.close handshaker ch (CloseWebSocketFrame.))))
 
      (let [s (doto
@@ -586,7 +586,7 @@
              (http/resolve-pings! pending-pings true)
 
              (instance? CloseWebSocketFrame msg)
-             (if-not (compare-and-set! closing? false true)
+             (if-not (.compareAndSet closing? false true)
                ;; closing already, nothing else could be done
                (netty/release msg)
                ;; reusing the same buffer

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -657,6 +657,8 @@
           (doto (.pipeline ch)
             (.remove "request-handler")
             (.remove "continue-handler")
+            (netty/remove-if-present HttpContentCompressor)
+            (netty/remove-if-present ChunkedWriteHandler)
             (.addLast "websocket-frame-aggregator" (WebSocketFrameAggregator. max-frame-size))
             (#(when compression?
                 (.addLast ^ChannelPipeline %

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -583,7 +583,9 @@
                (netty/write-and-flush ch (PongWebSocketFrame. body)))
 
              (instance? PongWebSocketFrame msg)
-             (http/resolve-pings! pending-pings true)
+             (do
+               (netty/release msg)
+               (http/resolve-pings! pending-pings true))
 
              (instance? CloseWebSocketFrame msg)
              (if-not (.compareAndSet closing? false true)

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -370,7 +370,9 @@
                 (d/success-deferred true)
 
                 (identical? sink-close-marker msg)
-                (d/success-deferred false)
+                (do
+                  (.markClosed this)
+                  (d/success-deferred false))
 
                 :else
                 (let [^ChannelFuture f (write-and-flush ch msg)]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -664,6 +664,11 @@
     (initChannel [^Channel ch]
       (pipeline-builder ^ChannelPipeline (.pipeline ch)))))
 
+(defn remove-if-present [^ChannelPipeline pipeline ^Class handler]
+  (when (some? (.get pipeline handler))
+    (.remove pipeline handler))
+  pipeline)
+
 (defn instrument!
   [stream]
   (if-let [^Channel ch (->> stream meta :aleph/channel)]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -329,7 +329,7 @@
       (when-let [^AtomicLong throughput (.get throughput ch)]
         {:throughput (.get throughput)}))))
 
-(def netty/sink-close-marker ::sink-close)
+(def sink-close-marker ::sink-close)
 
 (manifold/def-sink ChannelSink
   [coerce-fn
@@ -369,7 +369,7 @@
                 (nil? msg)
                 (d/success-deferred true)
 
-                (identical? netty/sink-close-marker msg)
+                (identical? sink-close-marker msg)
                 (d/success-deferred false)
 
                 :else

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -55,6 +55,17 @@
       (is @(s/put! c "hello with compression enabled"))
       (is (= "hello with compression enabled" @(s/try-take! c 5e3)))))
 
+  (with-compressing-handler echo-handler
+    (let [c @(http/websocket-client "ws://localhost:8080")]
+      (is @(s/put! c "hello"))
+      (is (= "hello" @(s/try-take! c 5e3)))))
+
+  (with-compressing-handler echo-handler
+    (let [c @(http/websocket-client "ws://localhost:8080" {:compression? true})]
+      (is @(s/put! c "hello compressed"))
+      (is (= "hello compressed" @(s/try-take! c 5e3))))))
+
+(deftest test-raw-echo-handler
   (testing "websocket client: raw-stream?"
     (with-handler echo-handler
       (let [c @(http/websocket-client "ws://localhost:8080" {:raw-stream? true})]
@@ -74,17 +85,7 @@
     (with-handler raw-echo-handler
       (let [c @(http/websocket-client "ws://localhost:8080")]
         (is @(s/put! c "raw conn string hello"))
-        (is (= "raw conn string hello" @(s/try-take! c 5e3))))))
-
-  (with-compressing-handler echo-handler
-    (let [c @(http/websocket-client "ws://localhost:8080")]
-      (is @(s/put! c "hello"))
-      (is (= "hello" @(s/try-take! c 5e3)))))
-
-  (with-compressing-handler echo-handler
-    (let [c @(http/websocket-client "ws://localhost:8080" {:compression? true})]
-      (is @(s/put! c "hello compressed"))
-      (is (= "hello compressed" @(s/try-take! c 5e3))))))
+        (is (= "raw conn string hello" @(s/try-take! c 5e3)))))))
 
 (deftest test-ping-pong-protocol
   (testing "empty ping from the client"

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -123,3 +123,21 @@
       (is @(s/put! c "hello raw handler 2"))
       (is (= "hello raw handler 2" @(s/try-take! c 5e3))))
     (is (= 400 (:status @(http/get "http://localhost:8081" {:throw-exceptions false}))))))
+
+(deftest test-server-connection-close
+  (testing "normal close"
+    (with-handler
+      (fn [req]
+        (d/chain'
+         (http/websocket-connection req)
+         (fn [conn]
+           (d/chain'
+            (http/websocket-close! conn 4001 "going away")
+            #(is (true? %))))))
+      @(http/websocket-client "ws://localhost:8080")))
+
+  (testing "rejected for closed connection")
+
+  (testing "subsequent write is rejected")
+
+  (testing "concurrent close attempts"))

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -135,6 +135,18 @@
      @closed#
      ~@body))
 
+(deftest test-client-connection-close
+  (with-handler echo-handler
+    (let [closed (d/deferred)
+          conn @(http/websocket-client "ws://localhost:8080")]
+      (s/on-closed conn #(d/success! closed true))
+      @(s/put! conn "message #1")
+      @(s/put! conn "message #2")
+      (let [cp (http/websocket-close! conn 4009 "back to roots")]
+        @closed
+        (is @cp "reported closed")
+        (is (false? @(http/websocket-close! conn)) "subsequent close")))))
+
 (deftest test-server-connection-close
   (testing "normal close"
     (let [handshake-started (d/deferred)

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -48,7 +48,8 @@
     (let [c @(http/websocket-client "ws://localhost:8080")]
       (is @(s/put! c "hello"))
       (is (= "hello" @(s/try-take! c 5e3))))
-    (is (= 400 (:status @(http/get "http://localhost:8080" {:throw-exceptions false})))))
+    (is (= 400 (:status @(http/get "http://localhost:8080"
+                                   {:throw-exceptions false})))))
 
   (with-handler echo-handler
     (let [c @(http/websocket-client "ws://localhost:8080" {:compression? true})]


### PR DESCRIPTION
> Quick note. This functionality has a lot of merge conflicts with #422.

Covers #470 and #478. 

@ztellman The only one thing I have doubts about... I had to update `netty/sink` to "close" itself when receiving a specific message, [here](https://github.com/ztellman/aleph/compare/master...kachayev:ft-websocket-close?expand=1#diff-95720affa86696b46c5458a71ab3e8d7R372). Should I just use `.markClosed` or I need to call `(s/close! this)`? All attempts to reimplement this without "self-closing" led to potential race conditions, so I choose this approach as the most reasonable.