### PR TITLE
100-Continue handler

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -48,7 +48,9 @@
    | `epoll?` | if `true`, uses `epoll` when available, defaults to `false`
    | `compression?` | when `true` enables http compression, defaults to `false`
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
-   | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds"
+   | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds
+   | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false` or deferred that yields either `true` or `false`.
+   | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread."
   [handler options]
   (server/start-server handler options))
 

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -49,7 +49,7 @@
    | `compression?` | when `true` enables http compression, defaults to `false`
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds
-   | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring response to be used as a reject response or deferred that yields one of those.
+   | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring responseo to be used as a reject response or deferred that yields one of those.
    | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread."
   [handler options]
   (server/start-server handler options))

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -49,7 +49,7 @@
    | `compression?` | when `true` enables http compression, defaults to `false`
    | `compression-level` | optional compression level, `1` yields the fastest compression and `9` yields the best compression, defaults to `6`. When set, enables http content compression regardless of the `compression?` flag value
    | `idle-timeout` | when set, forces keep-alive connections to be closed after an idle time, in milliseconds
-   | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false` or deferred that yields either `true` or `false`.
+   | `continue-handler` | optional handler which is invoked when header sends \"Except: 100-continue\" header to test whether the request should be accepted or rejected. Handler should return `true`, `false`, ring response to be used as a reject response or deferred that yields one of those.
    | `continue-executor` | optional `java.util.concurrent.Executor` which is used to handle requests passed to :continue-handler.  To avoid this indirection you may specify `:none`, but in this case extreme care must be taken to avoid blocking operations on the handler's thread."
   [handler options]
   (server/start-server handler options))

--- a/test/aleph/http_continue_test.clj
+++ b/test/aleph/http_continue_test.clj
@@ -1,0 +1,42 @@
+(ns aleph.http-continue-test
+  (:use [clojure test])
+  (:require [aleph.http :as sut]
+            [aleph
+             [http :as http]
+             [netty :as netty]
+             [flow :as flow]
+             [tcp :as tcp]]
+            [byte-streams :as bs]
+            [manifold.deferred :as d]
+            [manifold.stream :as s]
+            [clojure.string :as str]))
+
+(defmacro with-server [server & body]
+  `(let [server# ~server]
+     (try
+       ~@body
+       (finally
+         (.close ^java.io.Closeable server#)
+         (netty/wait-for-close server#)))))
+
+(def port 8082)
+
+(defn ok-handler [_]
+  {:status 200
+   :body "OK"})
+
+(defn pack-lines [lines]
+  (str (str/join "\r\n" lines) "\r\n\r\n"))
+
+(deftest test-default-continue-handler
+  (with-server (http/start-server ok-handler {:port port})
+    (let [c @(tcp/client {:host "localhost" :port port})]
+      @(s/put! c (pack-lines ["PUT /file HTTP/1.1"
+                              "Host: localhost"
+                              "Content-Length: 3"
+                              "Expect: 100-continue"]))
+      (let [resp-line @(s/try-take! c ::drained 1e3 ::timeout)]
+        (is (str/includes? (bs/to-string resp-line) "100 Continue")))
+      @(s/put! c (pack-lines ["OK?"]))
+      (let [finish-line @(s/try-take! c ::drained 1e3 ::timeout)]
+        (is (str/includes? (bs/to-string finish-line) "OK"))))))


### PR DESCRIPTION
Covers #462. 

Without any additional configuration works the same way as before (using an instance of `HttpServerExpectContinueHandler`). 

When provided, `:continue-handler` will be invoked with ring request w/o `:body`. It should respond with
* `true` to accept the request
* `false` to reject with a default "417 Expectation Failed" response 
* ring response to reject message with the response provided
* deferred that yields one of those

By default will be executed on the `response-executor` or on custom `continue-executor`. `:none` might be used to execute the handler inlined.

Note, that introducing "Expect: 100-continue" flow support for the client is pretty problematic as for now. Maybe it should be handled by Netty's `HttpClientCodec` but I need to do more experiments with the implementation.