### PR TITLE
http/file API to send region of the file

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -423,9 +423,9 @@
   "Specifies file or region of the file to be sent over the network"
   ([path]
    (file path nil nil nil))
-  ([path offset lenght]
-   (file path offset lenght nil))
-  ([path ^long offset ^long lenght ^long chunk-size]
+  ([path offset length]
+   (file path offset length nil))
+  ([path ^long offset ^long length ^long chunk-size]
    (let [^File
          fd (cond
               (string? path)
@@ -443,7 +443,7 @@
                 (str "cannot conver " (class path) " to file, "
                      "expected either string, java.io.File "
                      "or java.nio.file.Path"))))
-         region? (or (some? offset) (some? lenght))]
+         region? (or (some? offset) (some? length))]
      (when-not (.exists fd)
        (throw
         (IllegalArgumentException.
@@ -459,7 +459,7 @@
         (IllegalArgumentException.
          "offset of the region should be 0 or greater")))
 
-     (when (and region? (not (pos? lenght)))
+     (when (and region? (not (pos? length)))
        (throw
         (IllegalArgumentException.
          "length of the region should be greater than 0")))

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -419,12 +419,12 @@
       response)))
 
 (defn file
-  "Specifies file or region of the file to be sent over the network"
+  "Specifies a file or a region of the file to be sent over the network"
   ([path]
    (file path nil nil nil))
   ([path offset length]
    (file path offset length nil))
-  ([path ^long offset ^long length ^long chunk-size]
+  ([path offset length chunk-size]
    (let [^File
          fd (cond
               (string? path)

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -26,8 +26,7 @@
    [java.util.concurrent
     TimeoutException]
    [java.io File]
-   [java.nio.file Path]
-   [io.netty.handler.stream ChunkedStream]))
+   [java.nio.file Path]))
 
 (defn start-server
   "Starts an HTTP server using the provided Ring `handler`.  Returns a server object which can be stopped

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -440,11 +440,11 @@
 
 (defn file
   "Specifies a file or a region of the file to be sent over the network.
-   Accepts string path to the file, instance of java.io.File or instance of
-   java.nio.file.Path."
+   Accepts string path to the file, instance of `java.io.File` or instance of
+   `java.nio.file.Path`."
   ([path]
-   (http-core/new-http-file path nil nil nil))
+   (http-core/http-file path nil nil nil))
   ([path offset length]
-   (http-core/new-http-file path offset length nil))
+   (http-core/http-file path offset length nil))
   ([path offset length chunk-size]
-   (http-core/new-http-file path offset length chunk-size)))
+   (http-core/http-file path offset length chunk-size)))

--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -468,7 +468,7 @@
            [p c] (if region?
                    [offset length]
                    [0 len])
-           chunk-size (or chunk-size ChunkedStream/DEFAULT_CHUNK_SIZE)]
+           chunk-size (or chunk-size http-core/default-chunk-size)]
        (when (and region? (< len (+ offset length)))
          (throw
           (IllegalArgumentException.

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -340,7 +340,7 @@
   (HttpFile. fd 0 (.length fd) default-chunk-size))
 
 (defn send-chunked-file [ch ^HttpMessage msg ^HttpFile file]
-  (let [raf (RandomAccessFile. (.-fd file) "r")
+  (let [raf (RandomAccessFile. ^File (.-fd file) "r")
         cf (ChunkedFile. raf
                          (.-offset file)
                          (.-length file)
@@ -354,7 +354,7 @@
   (netty/write-and-flush ch body))
 
 (defn send-file-region [ch ^HttpMessage msg ^HttpFile file]
-  (let [raf (RandomAccessFile. (.-fd file) "r")
+  (let [raf (RandomAccessFile. ^File (.-fd file) "r")
         fc (.getChannel raf)
         fr (DefaultFileRegion. fc (.-offset file) (.-length file))]
     (try-set-content-length! msg (.-length file))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -346,7 +346,7 @@
                          (.-offset file)
                          (.-length file)
                          (.-chunk-size file))]
-    (try-set-content-length! msg len)
+    (try-set-content-length! msg (.-length file))
     (netty/write ch msg)
     (netty/write-and-flush ch (HttpChunkedInput. cf))))
 
@@ -358,7 +358,7 @@
   (let [raf (RandomAccessFile. (.-fd file) "r")
         fc (.getChannel raf)
         fr (DefaultFileRegion. fc (.-offset file) (.-length file))]
-    (try-set-content-length! msg len)
+    (try-set-content-length! msg (.-length file))
     (netty/write ch msg)
     (netty/write ch fr)
     (netty/write-and-flush ch empty-last-content)))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -342,6 +342,12 @@
 
 (deftype HttpFile [^File fd ^long offset ^long length ^long chunk-size])
 
+(defmethod print-method HttpFile [file ^java.io.Writer w]
+  (.write w (format "HttpFile[fd:%s offset:%s length:%s]"
+                    (.-fd file)
+                    (.-offset file)
+                    (.-length file))))
+
 (defn new-http-file
   ([path]
    (new-http-file path nil nil default-chunk-size))

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -38,7 +38,6 @@
     [io.netty.handler.stream
      ChunkedInput
      ChunkedFile
-     ChunkedStream
      ChunkedWriteHandler]
     [io.netty.handler.codec.http.websocketx
      WebSocketFrame

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -428,6 +428,8 @@
 
       f)))
 
+(deftype HttpFile [fd position count])
+
 (deftype WebsocketPing [deferred payload])
 
 (defn resolve-pings! [^ConcurrentLinkedQueue pending-pings v]

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -333,10 +333,12 @@
 
     (netty/write-and-flush ch empty-last-content)))
 
+(def default-chunk-size 8192)
+
 (deftype HttpFile [^File fd ^long offset ^long length ^long chunk-size])
 
 (defn ^HttpFile file->http-file [^File fd]
-  (HttpFile. fd 0 (.length fd) ChunkedStream/DEFAULT_CHUNK_SIZE))
+  (HttpFile. fd 0 (.length fd) default-chunk-size))
 
 (defn send-chunked-file [ch ^HttpMessage msg ^HttpFile file]
   (let [raf (RandomAccessFile. (.-fd file) "r")

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -349,11 +349,11 @@
                     (.-offset file)
                     (.-length file))))
 
-(defn new-http-file
+(defn http-file
   ([path]
-   (new-http-file path nil nil default-chunk-size))
+   (http-file path nil nil default-chunk-size))
   ([path offset length]
-   (new-http-file path offset length default-chunk-size))
+   (http-file path offset length default-chunk-size))
   ([path offset length chunk-size]
    (let [^File
          fd (cond
@@ -517,10 +517,10 @@
               (send-chunked-body ch msg body)
 
               (instance? File body)
-              (send-file-body ch ssl? msg (new-http-file body))
+              (send-file-body ch ssl? msg (http-file body))
 
               (instance? Path body)
-              (send-file-body ch ssl? msg (new-http-file body))
+              (send-file-body ch ssl? msg (http-file body))
 
               (instance? HttpFile body)
               (send-file-body ch ssl? msg body)

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -396,7 +396,7 @@
           (IllegalArgumentException.
            "the region exceeds the size of the file")))
 
-       (aleph.http.core.HttpFile. fd p c chunk-size)))))
+       (HttpFile. fd p c chunk-size)))))
 
 (bs/def-conversion ^{:cost 0} [HttpFile (bs/seq-of ByteBuffer)]
   [file {:keys [chunk-size writable?]
@@ -405,10 +405,10 @@
   (let [^RandomAccessFile raf (RandomAccessFile. ^File (.-fd file)
                                                  (if writable? "rw" "r"))
         ^FileChannel fc (.getChannel raf)
-        size (.-length file)
+        end-offset (+ (.-offset file) (.-length file))
         buf-seq (fn buf-seq [offset]
-                  (when-not (<= size offset)
-                    (let [remaining (- size offset)]
+                  (when-not (<= end-offset offset)
+                    (let [remaining (- end-offset offset)]
                       (lazy-seq
                        (cons
                         (.map fc

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -343,7 +343,7 @@
 
 (deftype HttpFile [^File fd ^long offset ^long length ^long chunk-size])
 
-(defmethod print-method HttpFile [file ^java.io.Writer w]
+(defmethod print-method HttpFile [^HttpFile file ^java.io.Writer w]
   (.write w (format "HttpFile[fd:%s offset:%s length:%s]"
                     (.-fd file)
                     (.-offset file)

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -53,9 +53,13 @@
 
 (def port 8082)
 
+(def filepath (str (System/getProperty "user.dir") "/test/file.txt"))
+
 (def string-response "String!")
 (def seq-response (map identity ["sequence: " 1 " two " 3.0]))
-(def file-response (File. (str (System/getProperty "user.dir") "/test/file.txt")))
+(def file-response (File. filepath))
+(def http-file-response (http/file filepath))
+(def http-file-region-response (http/file filepath 5 4))
 (def stream-response "Stream!")
 
 (defn string-handler [request]
@@ -69,6 +73,14 @@
 (defn file-handler [request]
   {:status 200
    :body file-response})
+
+(defn http-file-handler [request]
+  {:status 200
+   :body http-file-response})
+
+(defn http-file-region-handler [request]
+  {:status 200
+   :body http-file-region-response})
 
 (defn stream-handler [request]
   {:status 200
@@ -122,6 +134,8 @@
    "/stream" stream-handler
    "/slow" slow-handler
    "/file" file-handler
+   "/httpfile" http-file-handler
+   "/httpfileregion" http-file-region-handler
    "/manifold" manifold-handler
    "/seq" seq-handler
    "/string" string-handler
@@ -146,6 +160,8 @@
      "stream" stream-response
      "manifold" stream-response
      "file" "this is a file"
+     "httpfile" "this is a file"
+     "httpfileregion" "is a"
      "seq" (apply str seq-response)]
     (repeat 10)
     (apply concat)

--- a/test/aleph/http_test.clj
+++ b/test/aleph/http_test.clj
@@ -228,10 +228,11 @@
   (with-ssl-handler basic-handler
     (doseq [[index [path result]] (map-indexed vector expected-results)]
       (is
-        (= result
+       (= result
           (bs/to-string
-            (:body
-              @(http-get (str "https://localhost:" port "/" path)))))))))
+           (:body
+            @(http-get (str "https://localhost:" port "/" path)))))
+       (str path "path failed")))))
 
 (def words (slurp "/usr/share/dict/words"))
 


### PR DESCRIPTION
> Quick note. This PR clashes with #471 almost entirely. So.. Either #471 should be merged first, so I can reimplement the current one, or this one should be merged first, so I can reimplement #471.

Covers #469. The key motivation factor is byte range requests.

Now I can send as a body:

* `java.io.File`
* `java.nio.file.Path`
* `(aleph.http/file path)`
* `(aleph.http/file path offset length)`

It also extends API so I can set custom chunk size.