### PR TITLE
Carefully release buffers when processing websocket client stream

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -463,7 +463,7 @@
       CharSequence
       (TextWebSocketFrame. (bs/to-string msg))
 
-      (BinaryWebSocketFrame. (netty/to-byte-buf ch (netty/acquire msg))))))
+      (BinaryWebSocketFrame. (netty/to-byte-buf ch msg)))))
 
 (defn close-on-idle-handler []
   (netty/channel-handler

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -58,7 +58,8 @@
       (let [c @(http/websocket-client "ws://localhost:8080" {:raw-stream? true})]
         (is @(s/put! c (.getBytes "raw client hello" "UTF-8")))
         (let [msg @(s/try-take! c 5e3)]
-          (is (= "raw client hello" (when msg (bs/to-string (netty/buf->array msg)))))))))
+          (is (= "raw client hello"
+                 (when msg (bs/to-string (netty/release-buf->array msg)))))))))
 
   (testing "websocket server: raw-stream? with binary message"
     (with-handler raw-echo-handler


### PR DESCRIPTION
Fixes #489.

Actually, there was a problem with the test. If we use `:raw-stream? true` on the client, we need to clean up buffers after using them.

I also refactored acquire/release code for the client the same way it was done previously for the server. Having a huge try/finally block is really hard to follow with double acquires. Now it looks way cleaner. 

I also left a comment in the code about reallocation of the `ByteBuf` [here](https://github.com/ztellman/aleph/compare/master...kachayev:fix-websocket-client-release?expand=1#diff-95720affa86696b46c5458a71ab3e8d7R188). Not sure if really need this (it seems we can just return the same buffer given). @ztellman WDYT?