### PR TITLE
Show the channel when printing `AlephServer` object

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -957,6 +957,11 @@
           EpollServerSocketChannel
           NioServerSocketChannel)
 
+        ;; todo(kachayev): this one should be reimplemented after
+        ;;                 KQueue transport is merged into master
+        transport
+        (if (and epoll? (epoll-available?)) :epoll :nio)
+
         pipeline-builder
         (if ssl-context
           (fn [^ChannelPipeline p]
@@ -990,6 +995,9 @@
                 (d/chain'
                  (wrap-future (.terminationFuture group))
                  (fn [_] (on-close))))))
+          Object
+          (toString [_]
+            (format "AlephServer[channel:%s, transport:%s]" ch transport))
           AlephServer
           (port [_]
             (-> ch .localAddress .getPort))


### PR DESCRIPTION
Tiny operational improvement. Now you can actually see Netty's channel, address, port, and the transport used.

```clojure
user> (def server (http/start-server (fn [_] {:status 200 :body "OK"}) {:port 2020}))
server
user> server
#object[aleph.netty$start_server$reify__53226 0x5f495e42 "AlephServer[channel:[id: 0x75644268, L:/0:0:0:0:0:0:0:0:2020], transport::nio]"]
```

We can even go further and implement `print-method` but `AlephServer` does not expose the underlying channel. And I don't want to extend the protocol just to deal with printing.