### PR TITLE
If using a domain socket, start a EpollServerDomainSocketChannel

### DIFF
--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -26,7 +26,9 @@
      ChannelInitializer]
     [io.netty.channel.epoll Epoll EpollEventLoopGroup
      EpollServerSocketChannel
+     EpollServerDomainSocketChannel
      EpollSocketChannel]
+    [io.netty.channel.unix DomainSocketAddress]
     [io.netty.util Attribute AttributeKey]
     [io.netty.handler.codec Headers]
     [io.netty.channel.nio NioEventLoopGroup]
@@ -954,7 +956,9 @@
 
         ^Class channel
         (if (and epoll? (epoll-available?))
-          EpollServerSocketChannel
+          (if (and socket-address (instance? DomainSocketAddress socket-address))
+            EpollServerDomainSocketChannel
+            EpollServerSocketChannel)
           NioServerSocketChannel)
 
         pipeline-builder


### PR DESCRIPTION
This checks if the socket address being passed in is a local Unix domain socket, without with starting a server to listen to a unix domain socket not work.

With this, I'm able to start a server like 
```clojure
(require '[clojure.java.io :as io])
(require '[aleph.http :as http])
(import '(io.netty.channel.unix DomainSocketAddress))

(defn handler
  [req]
  (prn "REQ" req)
  {:status 200
   :headers {"Content-Type" "text/plain"}
   :body "Hello!"})

(http/start-server handler {:socket-address (DomainSocketAddress. (io/file "foobar.sock"))
                                            :epoll? true}))
```

This creates a listening socket that I can send requests to like `curl --unix-socket foobar.sock http:/test`