### PR TITLE
Use shared instance of LoggingHandler for the connection pool

### DIFF
--- a/src/aleph/http.clj
+++ b/src/aleph/http.clj
@@ -154,9 +154,13 @@
      (IllegalArgumentException.
       ":idle-timeout option is not allowed when :keep-alive? is explicitly disabled")))
 
-  (let [conn-options' (cond-> connection-options
+  (let [log-activity (:log-activity connection-options)
+        conn-options' (cond-> connection-options
                         (some? dns-options)
-                        (assoc :name-resolver (netty/dns-resolver-group dns-options)))
+                        (assoc :name-resolver (netty/dns-resolver-group dns-options))
+
+                        (some? log-activity)
+                        (assoc :log-activity (netty/activity-logger "aleph-client" log-activity)))
         p (promise)
         pool (flow/instrumented-pool
                {:generate (fn [host]

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -63,8 +63,7 @@
      Socks4ProxyHandler
      Socks5ProxyHandler]
     [io.netty.handler.logging
-     LoggingHandler
-     LogLevel]
+     LoggingHandler]
     [java.util.concurrent
      ConcurrentLinkedQueue]
     [java.util.concurrent.atomic
@@ -377,21 +376,6 @@
         (.remove (.pipeline ctx) this))
       (.fireUserEventTriggered ^ChannelHandlerContext ctx evt))))
 
-(defn coerce-log-level [level]
-  (if (instance? LogLevel level)
-    level
-    (let [netty-level (case level
-                        :trace LogLevel/TRACE
-                        :debug LogLevel/DEBUG
-                        :info LogLevel/INFO
-                        :warn LogLevel/WARN
-                        :error LogLevel/ERROR
-                        nil)]
-      (when (nil? netty-level)
-        (throw (IllegalArgumentException.
-                (str "unknown log level given: " level))))
-      netty-level)))
-
 (defn pipeline-builder
   [response-stream
    {:keys
@@ -416,10 +400,15 @@
     (let [handler (if raw-stream?
                     (raw-client-handler response-stream response-buffer-size)
                     (client-handler response-stream response-buffer-size))
-          logger (when (some? log-activity)
-                   (LoggingHandler.
-                    "aleph-client"
-                    ^LogLevel (coerce-log-level log-activity)))]
+          logger (cond
+                   (instance? LoggingHandler log-activity)
+                   log-activity
+
+                   (some? log-activity)
+                   (netty/activity-logger "aleph-client" log-activity)
+
+                   :else
+                   nil)]
       (doto pipeline
         (.addLast "http-client"
           (HttpClientCodec.
@@ -444,7 +433,7 @@
               ^ChannelHandler
               (pending-proxy-connection-handler response-stream)))))
       (when (some? logger)
-        (.addFirst pipeline "activity-logger" logger))
+        (.addFirst pipeline "activity-logger" ^ChannelHandler logger))
       (pipeline-transform pipeline))))
 
 (defn close-connection [f]

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -70,6 +70,9 @@
      Slf4JLoggerFactory
      JdkLoggerFactory
      Log4J2LoggerFactory]
+    [io.netty.handler.logging
+     LoggingHandler
+     LogLevel]
     [java.security.cert X509Certificate]
     [java.security PrivateKey]))
 
@@ -666,6 +669,27 @@
             (.addFirst pipeline "bandwidth-tracker" (bandwidth-tracker ch)))))
       true)
     false))
+
+(defn coerce-log-level [level]
+  (if (instance? LogLevel level)
+    level
+    (let [netty-level (case level
+                        :trace LogLevel/TRACE
+                        :debug LogLevel/DEBUG
+                        :info LogLevel/INFO
+                        :warn LogLevel/WARN
+                        :error LogLevel/ERROR
+                        nil)]
+      (when (nil? netty-level)
+        (throw (IllegalArgumentException.
+                (str "unknown log level given: " level))))
+      netty-level)))
+
+(defn activity-logger
+  ([level]
+   (LoggingHandler. ^LogLevel (coerce-log-level level)))
+  ([^String name level]
+   (LoggingHandler. name ^LogLevel (coerce-log-level level))))
 
 ;;;
 


### PR DESCRIPTION
`LoggingHandler` is shareable and we don't need to create a new instance per each connection. The new implementation uses a single logger for all connections within the same connections pool.

I've also moved a few helper functions to `netty` module in order to provide `log-activity` capabilities for a server (after other PRs would be merged, right now it will create a lot of merge conflicts).