### PR TITLE
Bump to Netty 4.1.34.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.33.Final")
+(def netty-version "4.1.34.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Here come Netty 4.1.34.Final :smile: 

The changelog is found under https://netty.io/news/2019/03/08/4-1-34-Final.html .