### PR TITLE
Use HttpUtil to manage Content-Length header

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -237,11 +237,11 @@
 ;;;
 
 (defn has-content-length? [^HttpMessage msg]
-  (-> msg .headers (.contains "Content-Length")))
+  (HttpUtil/isContentLengthSet msg))
 
 (defn try-set-content-length! [^HttpMessage msg ^long length]
   (when-not (has-content-length? msg)
-    (HttpHeaders/setContentLength msg length)))
+    (HttpUtil/setContentLength msg length)))
 
 (def empty-last-content LastHttpContent/EMPTY_LAST_CONTENT)
 


### PR DESCRIPTION
Previously used `HttpHeaders` methods are deprecated.