### PR TITLE
WebSocket connection to expose more information about handshake result 

### DIFF
--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -698,6 +698,11 @@
                                     ch
                                     pending-pings
                                     close-fn)
+                         headers (http/headers->map (.headers ^HttpResponse msg))
+                         subprotocol (.actualSubprotocol handshaker)
+                         _ (swap! desc assoc
+                                  :websocket-handshake-headers headers
+                                  :websocket-selected-subprotocol subprotocol)
                          out (netty/sink ch false coerce-fn (fn [] @desc))]
 
                      (s/on-closed out (fn [] (http/resolve-pings! pending-pings false)))

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -682,6 +682,9 @@
 
             (not (.isHandshakeComplete handshaker))
             (try
+              ;; Here we rely on the HttpObjectAggregator being added
+              ;; to the pipeline in advance, so there's no chance we
+              ;; could read only a partial request
               (.finishHandshake handshaker ch msg)
               (let [close-fn (fn [^CloseWebSocketFrame frame]
                                (if-not (.compareAndSet closing? false true)

--- a/src/aleph/http/client.clj
+++ b/src/aleph/http/client.clj
@@ -705,7 +705,7 @@
                                   :websocket-selected-subprotocol subprotocol)
                          out (netty/sink ch false coerce-fn (fn [] @desc))]
 
-                     (s/on-closed out (fn [] (http/resolve-pings! pending-pings false)))
+                     (s/on-closed out #(http/resolve-pings! pending-pings false))
 
                      (d/success! d
                                  (doto

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -513,9 +513,7 @@
          out (netty/sink ch false coerce-fn)
          in (netty/buffered-source ch (constantly 1) 16)]
 
-     (s/on-closed
-      out
-      (fn [] (http/resolve-pings! pending-pings false)))
+     (s/on-closed out #(http/resolve-pings! pending-pings false))
 
      (s/on-drained
       in

--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -510,7 +510,8 @@
                         (do
                           (.close handshaker ch frame)
                           true))))
-         out (netty/sink ch false coerce-fn)
+         description (fn [] {:websocket-selected-subprotocol (.selectedSubprotocol handshaker)})
+         out (netty/sink ch false coerce-fn description)
          in (netty/buffered-source ch (constantly 1) 16)]
 
      (s/on-closed out #(http/resolve-pings! pending-pings false))

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -35,13 +35,21 @@
 
 (defn echo-handler [req]
   (-> (http/websocket-connection req)
-    (d/chain #(s/connect % %))
-    (d/catch (fn [e] (log/error "upgrade to websocket conn failed" e) {}))))
+    (d/chain' #(s/connect % %))
+    (d/catch'
+        (fn [^Throwable e]
+          (log/error "upgrade to websocket conn failed"
+                     (.getMessage e))
+          {}))))
 
 (defn raw-echo-handler [req]
   (-> (http/websocket-connection req {:raw-stream? true})
-    (d/chain #(s/connect % %))
-    (d/catch (fn [e] (log/error "upgrade to websocket conn failed" e) {}))))
+    (d/chain' #(s/connect % %))
+    (d/catch'
+        (fn [^Throwable e]
+          (log/error "upgrade to websocket conn failed"
+                     (.getMessage e))
+          {}))))
 
 (deftest test-echo-handler
   (with-handler echo-handler

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -67,6 +67,18 @@
       (is @(s/put! c "hello compressed"))
       (is (= "hello compressed" @(s/try-take! c 5e3))))))
 
+(deftest test-server-handshake-description
+  (with-handler (fn [req]
+                  (-> (http/websocket-connection req)
+                      (d/chain'
+                       (fn [s]
+                         (let [desc (:sink (s/description s))
+                               c (contains? desc :websocket-selected-subprotocol)]
+                           (s/put! s (if c "YES" "NO"))
+                           (s/close! s))))))
+    (let [c @(http/websocket-client "ws://localhost:8080")]
+      (is (= "YES" @(s/try-take! c 5e3))))))
+
 (deftest test-raw-echo-handler
   (testing "websocket client: raw-stream?"
     (with-handler echo-handler

--- a/test/aleph/websocket_test.clj
+++ b/test/aleph/websocket_test.clj
@@ -47,7 +47,8 @@
   (with-handler echo-handler
     (let [c @(http/websocket-client "ws://localhost:8080")]
       (is @(s/put! c "hello"))
-      (is (= "hello" @(s/try-take! c 5e3))))
+      (is (= "hello" @(s/try-take! c 5e3)))
+      (is (= "upgrade" (get-in (s/description c) [:sink :websocket-handshake-headers "connection"]))))
     (is (= 400 (:status @(http/get "http://localhost:8080"
                                    {:throw-exceptions false})))))
 


### PR DESCRIPTION
When working with different subprotocols you need to have access to the result of the handshaking negotiation. Response headers are also captured for the client, e.g. to deal with situations like #494.

I've also reverted back some changes I did a long time ago regarding WebSocket client handshake processing. Previously I thought that the old approach leads to leaks, but that was a wrong assumption.