### PR TITLE
Helper to extract SSL session from the request

### DIFF
--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -47,6 +47,8 @@
      TextWebSocketFrame
      BinaryWebSocketFrame
      CloseWebSocketFrame]
+    [io.netty.handler.ssl
+     SslHandler]
     [java.io
      File
      RandomAccessFile
@@ -241,6 +243,10 @@
 
 (defn netty-response->ring-response [rsp complete body]
   (->NettyResponse rsp complete body))
+
+(defn extract-ssl-session [^NettyRequest req]
+  (let [pipeline ^ChannelPipeline (.pipeline (.ch req))]
+    (some-> pipeline (.get SslHandler) .engine .getSession)))
 
 ;;;
 

--- a/src/aleph/http/core.clj
+++ b/src/aleph/http/core.clj
@@ -47,8 +47,6 @@
      TextWebSocketFrame
      BinaryWebSocketFrame
      CloseWebSocketFrame]
-    [io.netty.handler.ssl
-     SslHandler]
     [java.io
      File
      RandomAccessFile
@@ -244,9 +242,8 @@
 (defn netty-response->ring-response [rsp complete body]
   (->NettyResponse rsp complete body))
 
-(defn extract-ssl-session [^NettyRequest req]
-  (let [pipeline ^ChannelPipeline (.pipeline (.ch req))]
-    (some-> pipeline (.get SslHandler) .engine .getSession)))
+(defn ring-request-ssl-session [^NettyRequest req]
+  (netty/channel-ssl-session (.ch req)))
 
 ;;;
 

--- a/src/aleph/netty.clj
+++ b/src/aleph/netty.clj
@@ -36,7 +36,10 @@
      NioServerSocketChannel
      NioSocketChannel
      NioDatagramChannel]
-    [io.netty.handler.ssl SslContext SslContextBuilder]
+    [io.netty.handler.ssl
+     SslContext
+     SslContextBuilder
+     SslHandler]
     [io.netty.handler.ssl.util
      SelfSignedCertificate InsecureTrustManagerFactory]
     [io.netty.resolver
@@ -767,6 +770,12 @@
 
 (set! *warn-on-reflection* true)
 
+(defn channel-ssl-session [^Channel ch]
+  (some-> ch
+          ^ChannelPipeline (.pipeline)
+          ^SslHandler (.get SslHandler)
+          .engine
+          .getSession))
 ;;;
 
 (defprotocol AlephServer

--- a/src/aleph/tcp.clj
+++ b/src/aleph/tcp.clj
@@ -13,15 +13,13 @@
     [io.netty.channel
      Channel
      ChannelHandler
-     ChannelPipeline]
-    [io.netty.handler.ssl
-     SslHandler]))
+     ChannelPipeline]))
 
 (p/def-derived-map TcpConnection [^Channel ch]
   :server-name (netty/channel-server-name ch)
   :server-port (netty/channel-server-port ch)
   :remote-addr (netty/channel-remote-address ch)
-  :ssl-session (some-> ch ^ChannelPipeline (.pipeline) ^SslHandler (.get "ssl-handler") .engine .getSession))
+  :ssl-session (netty/channel-ssl-session ch))
 
 (alter-meta! #'->TcpConnection assoc :private true)
 

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -68,6 +68,7 @@
 
 (defn ssl-echo-handler
   [s c]
+  (assert (some? (:ssl-session c)) "SSL session should be defined")
   (s/connect
     ; note we need to inspect the SSL session *after* we start reading
     ; data. Otherwise, the session might not be set up yet.
@@ -79,7 +80,11 @@
     s))
 
 (deftest test-ssl-echo
-  (with-server (tcp/start-server ssl-echo-handler {:port 10001 :ssl-context server-ssl-context})
-    (let [c @(tcp/client {:host "localhost" :port 10001 :ssl-context client-ssl-context})]
+  (with-server (tcp/start-server ssl-echo-handler
+                                 {:port 10001
+                                  :ssl-context server-ssl-context})
+    (let [c @(tcp/client {:host "localhost"
+                          :port 10001
+                          :ssl-context client-ssl-context})]
       (s/put! c "foo")
       (is (= "foo" (bs/to-string @(s/take! c)))))))

--- a/test/aleph/tcp_ssl_test.clj
+++ b/test/aleph/tcp_ssl_test.clj
@@ -68,7 +68,7 @@
 
 (defn ssl-echo-handler
   [s c]
-  (assert (some? (:ssl-session c)) "SSL session should be defined")
+  (is (some? (:ssl-session c)) "SSL session should be defined")
   (s/connect
     ; note we need to inspect the SSL session *after* we start reading
     ; data. Otherwise, the session might not be set up yet.


### PR DESCRIPTION
Covers https://github.com/ztellman/aleph/issues/501.

Similar functionality for TCP is also updated not to rely on a specific handler name.