### PR TITLE
Upgrade Netty to 4.1.36.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.34.Final")
+(def netty-version "4.1.35.Final")
 
 (def netty-modules
   '[transport

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.35.Final")
+(def netty-version "4.1.36.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Mostly because of [this](https://github.com/netty/netty/pull/8896).

I'm going to implement a configuration after all websocket-related PRs are merged not to introduce new merge conflicts.