### PR TITLE
Attach idle handlers before other handlers

### DIFF
--- a/src/aleph/http/server.clj
+++ b/src/aleph/http/server.clj
@@ -489,6 +489,7 @@
                                                    ssl?))]
 
       (doto pipeline
+        (http/attach-idle-handlers idle-timeout)
         (.addLast "http-server"
           (HttpServerCodec.
             max-initial-line-length
@@ -501,7 +502,6 @@
             (let [compressor (HttpContentCompressor. (or compression-level 6))]
               (.addAfter ^ChannelPipeline %1 "http-server" "deflater" compressor))
             (.addAfter ^ChannelPipeline %1 "deflater" "streamer" (ChunkedWriteHandler.))))
-        (http/attach-idle-handlers idle-timeout)
         pipeline-transform))))
 
 ;;;


### PR DESCRIPTION
Having the idle handlers after the other handlers results in them timing out the connection after the timeout without any consideration of actual traffic. This can lead to a socket being closed while it is still actively being used. Attaching the idle handlers first means that a connection will only be treated as idle if no traffic has been sent through the socket for a given period of time.

This is leading a problem in production for us, where Aleph would terminate connections while a request was in-flight (~20ms after receiving the data) because the connection was older than the request. We have disabled the idle-timeout to get things working for now, but this change will fix things properly.