### PR TITLE
Upgrade to Netty 4.1.37.Final

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def netty-version "4.1.36.Final")
+(def netty-version "4.1.37.Final")
 
 (def netty-modules
   '[transport


### PR DESCRIPTION
Changelog available on https://netty.io/news/2019/06/28/4-1-37-Final.html